### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,4 @@
+## Version 0.1.1, 2017.02.20
+
+* Cache poisoning possible for package information [#2](https://github.com/Skelp/knockknock/issues/2)
+* Include column number in caller information [#3](https://github.com/Skelp/knockknock/issues/3)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
 ## Version 0.1.1, 2017.02.20
 
-* Cache poisoning possible for package information [#2](https://github.com/Skelp/knockknock/issues/2)
-* Include column number in caller information [#3](https://github.com/Skelp/knockknock/issues/3)
+* Cache poisoning possible for package information [#2](https://github.com/Skelp/node-knockknock/issues/2)
+* Include column number in caller information [#3](https://github.com/Skelp/node-knockknock/issues/3)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Version 0.2.0, 2017.02.21
+
+* Add filterPackages option for more granular control over package exclusion [#5](https://github.com/Skelp/node-knockknock/issues/5)
+* Add filterFiles option for more granular control over file exclusion [#6](https://github.com/Skelp/node-knockknock/issues/6)
+* Return information for all callers [#7](https://github.com/Skelp/node-knockknock/issues/7) (**breaking change**)
+* Rename Git repository to node-knockknock [#9](https://github.com/Skelp/node-knockknock/issues/9)
+* Add offset option for more control over initial call stack offset [#10](https://github.com/Skelp/node-knockknock/issues/10)
+* All calls from start of stack from within originator module should be ignored [#11](https://github.com/Skelp/node-knockknock/issues/11)
+
 ## Version 0.1.1, 2017.02.20
 
 * Cache poisoning possible for package information [#2](https://github.com/Skelp/node-knockknock/issues/2)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing
 
-If you have any questions about [KnockKnock](https://github.com/Skelp/knockknock) please feel free to
-[raise an issue](https://github.com/Skelp/knockknock/issues/new).
+If you have any questions about [KnockKnock](https://github.com/Skelp/node-knockknock) please feel free to
+[raise an issue](https://github.com/Skelp/node-knockknock/issues/new).
 
-Please [search existing issues](https://github.com/Skelp/knockknock/issues) for the same feature and/or issue before
-raising a new issue. Commenting on an existing issue is usually preferred over raising duplicate issues.
+Please [search existing issues](https://github.com/Skelp/node-knockknock/issues) for the same feature and/or issue
+before raising a new issue. Commenting on an existing issue is usually preferred over raising duplicate issues.
 
 Please ensure that all files conform to the coding standards, using the same coding style as the rest of the code base.
 All unit tests should be updated and passing as well. All of this can easily be checked via command-line:
@@ -21,5 +21,5 @@ You must have at least [Node.js](https://nodejs.org) 4 or newer.
 All pull requests should be made to the `develop` branch.
 
 Don't forget to add your details to the list of
-[AUTHORS.md](https://github.com/Skelp/knockknock/blob/master/AUTHORS.md) if you want your contribution to be recognized
-by others.
+[AUTHORS.md](https://github.com/Skelp/node-knockknock/blob/master/AUTHORS.md) if you want your contribution to be
+recognized by others.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The current version of KnockKnock.
 const whoIsThere = require('knockknock')
 
 whoIsThere.version
-=> "0.1.0alpha"
+=> "0.1.0"
 ```
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@
 Who's there?  
 The modules that just called your code.
 
-[KnockKnock](https://github.com/Skelp/knockknock) provides information about the files, functions, and packages that
+[KnockKnock](https://github.com/Skelp/node-knockknock) provides information about the files, functions, and packages that
 were responsible for calling your module.
 
-[![Build](https://img.shields.io/travis/Skelp/knockknock/develop.svg?style=flat-square)](https://travis-ci.org/Skelp/knockknock)
-[![Coverage](https://img.shields.io/coveralls/Skelp/knockknock/develop.svg?style=flat-square)](https://coveralls.io/github/Skelp/knockknock)
-[![Dependencies](https://img.shields.io/david/Skelp/knockknock.svg?style=flat-square)](https://david-dm.org/Skelp/knockknock)
-[![Dev Dependencies](https://img.shields.io/david/dev/Skelp/knockknock.svg?style=flat-square)](https://david-dm.org/Skelp/knockknock#info=devDependencies)
-[![License](https://img.shields.io/npm/l/knockknock.svg?style=flat-square)](https://github.com/Skelp/knockknock/blob/master/LICENSE.md)
+[![Build](https://img.shields.io/travis/Skelp/node-knockknock/develop.svg?style=flat-square)](https://travis-ci.org/Skelp/node-knockknock)
+[![Coverage](https://img.shields.io/coveralls/Skelp/node-knockknock/develop.svg?style=flat-square)](https://coveralls.io/github/Skelp/node-knockknock)
+[![Dependencies](https://img.shields.io/david/Skelp/node-knockknock.svg?style=flat-square)](https://david-dm.org/Skelp/node-knockknock)
+[![Dev Dependencies](https://img.shields.io/david/dev/Skelp/node-knockknock.svg?style=flat-square)](https://david-dm.org/Skelp/node-knockknock#info=devDependencies)
+[![License](https://img.shields.io/npm/l/knockknock.svg?style=flat-square)](https://github.com/Skelp/node-knockknock/blob/master/LICENSE.md)
 [![Release](https://img.shields.io/npm/v/knockknock.svg?style=flat-square)](https://www.npmjs.com/package/knockknock)
 
 * [Install](#install)
@@ -153,20 +153,21 @@ whoIsThere.version
 ## Bugs
 
 If you have any problems with KnockKnock or would like to see changes currently in development you can do so
-[here](https://github.com/Skelp/knockknock/issues).
+[here](https://github.com/Skelp/node-knockknock/issues).
 
 ## Contributors
 
 If you want to contribute, you're a legend! Information on how you can do so can be found in
-[CONTRIBUTING.md](https://github.com/Skelp/knockknock/blob/master/CONTRIBUTING.md). We want your suggestions and pull
-requests!
+[CONTRIBUTING.md](https://github.com/Skelp/node-knockknock/blob/master/CONTRIBUTING.md). We want your suggestions and
+pull requests!
 
 A list of KnockKnock contributors can be found in
-[AUTHORS.md](https://github.com/Skelp/knockknock/blob/master/AUTHORS.md).
+[AUTHORS.md](https://github.com/Skelp/node-knockknock/blob/master/AUTHORS.md).
 
 ## License
 
-See [LICENSE.md](https://github.com/Skelp/knockknock/raw/master/LICENSE.md) for more information on our MIT license.
+See [LICENSE.md](https://github.com/Skelp/node-knockknock/raw/master/LICENSE.md) for more information on our MIT
+license.
 
 © 2017 [Skelp](https://skelp.io)
 <img align="right" width="16" height="16" src="https://cdn.rawgit.com/Skelp/skelp-branding/master/assets/logo/base/skelp-logo-16x16.png">

--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ If no caller can be determined (or all belong to excluded packages), then the `P
 
 The `options` parameter is entirely optional and supports the following:
 
-| Option           | Description                                                                                                           | Default Value |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------- | ------------- |
-| `excludes`       | The name(s) of packages whose calls should be ignored. Internal calls from KnockKnock and Node.js are always ignored. | `[]`          |
-| `filterPackages` | A function called to filter files based on the package to which they belong (if any).                                 | N/A           |
+| Option           | Description                                                                                                                               | Default Value |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `excludes`       | The name(s) of packages whose calls should be ignored. Internal calls from KnockKnock and Node.js are always ignored.                     | `[]`          |
+| `filterPackages` | A function called to filter files based on the package to which they belong (if any). Only called if package is not listed in `excludes`. | N/A           |
 
 In most cases you'll want to at least exclude your own package so that your own internal calls are ignored via
 `excludes` or `filterPackages`.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The `options` parameter is entirely optional and supports the following:
 | Option           | Description                                                                                                                               | Default Value |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `excludes`       | The name(s) of packages whose calls should be ignored. Internal calls from KnockKnock and Node.js are always ignored.                     | `[]`          |
-| `filterFiles` | A function called to filter files based on their path. Only called for files whose containing package (if any) is also included.             | N/A           |
+| `filterFiles`    | A function called to filter files based on their path. Only called for files whose containing package (if any) is also included.          | N/A           |
 | `filterPackages` | A function called to filter files based on the package to which they belong (if any). Only called if package is not listed in `excludes`. | N/A           |
 
 In most cases you'll want to at least exclude your own package so that your own internal calls are ignored via

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The `options` parameter is entirely optional and supports the following:
 | `filterFiles`    | A function called to filter files based on their path. Only called for files whose containing package (if any) is also included.          | N/A           |
 | `filterPackages` | A function called to filter files based on the package to which they belong (if any). Only called if package is not listed in `excludes`. | N/A           |
 | `limit`          | The maximum number of callers to be included in the results. No limit is applied when `null`.                                             | `null`        |
+| `offset`         | The number of frames from call stack to be skipped initially.                                                                             | `0`           |
 
 In most cases, you may want to at least exclude your own package so that your own package-internal calls are ignored via
 `excludes` or `filterPackages`.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The current version of KnockKnock.
 const whoIsThere = require('knockknock')
 
 whoIsThere.version
-=> "0.1.0"
+=> "0.1.1"
 ```
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The current version of KnockKnock.
 const whoIsThere = require('knockknock')
 
 whoIsThere.version
-=> "0.1.1"
+=> "0.2.0"
 ```
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The `options` parameter is entirely optional and supports the following:
 | Option           | Description                                                                                                                               | Default Value |
 | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
 | `excludes`       | The name(s) of packages whose calls should be ignored. Internal calls from KnockKnock and Node.js are always ignored.                     | `[]`          |
+| `filterFiles` | A function called to filter files based on their path. Only called for files whose containing package (if any) is also included.             | N/A           |
 | `filterPackages` | A function called to filter files based on the package to which they belong (if any). Only called if package is not listed in `excludes`. | N/A           |
 
 In most cases you'll want to at least exclude your own package so that your own internal calls are ignored via

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ If no caller can be determined (or all belong to excluded packages), then the `P
 
 The `options` parameter is entirely optional and supports the following:
 
-| Option     | Description                                                                                                           |
-| ---------- | --------------------------------------------------------------------------------------------------------------------- |
-| `excludes` | The name(s) of packages whose calls should be ignored. Internal calls from KnockKnock and Node.js are always ignored. |
+| Option           | Description                                                                                                           | Default Value |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------- | ------------- |
+| `excludes`       | The name(s) of packages whose calls should be ignored. Internal calls from KnockKnock and Node.js are always ignored. | `[]`          |
+| `filterPackages` | A function called to filter files based on the package to which they belong (if any).                                 | N/A           |
 
-In most cases you'll want to at least exclude your own package so that your own internal calls are ignored.
+In most cases you'll want to at least exclude your own package so that your own internal calls are ignored via
+`excludes` or `filterPackages`.
 
 ``` javascript
 const whoIsThere = require('knockknock')
@@ -84,7 +86,7 @@ module.exports = function() {
 
         // ...
       } else {
-        console.log(`Module was called from file: ${caller.file}`)
+        console.log(`Module was called from file "${caller.file}" in package "${caller.package ? caller.package.name : '<unknown>'}"`)
 
         // ...
       }
@@ -107,7 +109,7 @@ module.exports = function() {
 
     // ...
   } else {
-    console.log(`Module was called from file: ${caller.file}`)
+    console.log(`Module was called from file "${caller.file}" in package "${caller.package ? caller.package.name : '<unknown>'}"`)
 
     // ...
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.16",
-    "eslint": "^3.15.0",
+    "eslint": "^3.16.0",
     "eslint-config-skelp": "^0.1.5",
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "knockknock",
   "version": "0.2.0",
-  "description": "Who's there? The module that just called your code",
+  "description": "Who's there? The modules that just called your code",
   "homepage": "https://github.com/Skelp/knockknock",
   "bugs": {
     "url": "https://github.com/Skelp/knockknock/issues"
@@ -16,6 +16,7 @@
     "caller",
     "callsite",
     "stack",
+    "trace",
     "knock",
     "module",
     "package"

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "knockknock",
   "version": "0.2.0",
   "description": "Who's there? The modules that just called your code",
-  "homepage": "https://github.com/Skelp/knockknock",
+  "homepage": "https://github.com/Skelp/node-knockknock",
   "bugs": {
-    "url": "https://github.com/Skelp/knockknock/issues"
+    "url": "https://github.com/Skelp/node-knockknock/issues"
   },
   "author": {
     "name": "Alasdair Mercer",
@@ -23,7 +23,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Skelp/knockknock.git"
+    "url": "https://github.com/Skelp/node-knockknock.git"
   },
   "dependencies": {
     "callsite": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knockknock",
-  "version": "0.1.0alpha",
+  "version": "0.1.0",
   "description": "Who's there? The module that just called your code",
   "homepage": "https://github.com/Skelp/knockknock",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^3.2.0",
     "ncp": "^2.0.0",
-    "tmp": "0.0.31"
+    "tmp": "^0.0.31"
   },
   "main": "src/knockknock.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knockknock",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Who's there? The module that just called your code",
   "homepage": "https://github.com/Skelp/knockknock",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knockknock",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Who's there? The module that just called your code",
   "homepage": "https://github.com/Skelp/knockknock",
   "bugs": {

--- a/src/knockknock.js
+++ b/src/knockknock.js
@@ -63,7 +63,7 @@ class Finder {
       file: filePath,
       line: frame.getLineNumber(),
       name: frame.getFunctionName() || '<anonymous>',
-      package: descriptor
+      package: descriptor ? Object.assign({}, descriptor) : null
     }
   }
 

--- a/src/knockknock.js
+++ b/src/knockknock.js
@@ -218,14 +218,10 @@ class KnockKnock {
     /**
      * The call stack captured by this {@link KnockKnock}.
      *
-     * The first 3 frames are excluded from the stack as these will always relate to either this module (i.e.
-     * <code>knockknock.js</code>) or the module that is trying to determine its caller. The <code>offset</cod> option
-     * is then applied on top of this.
-     *
      * @private
      * @type {CallSite[]}
      */
-    this._stack = getStack().slice(3 + this._options.offset)
+    this._stack = this._getStack()
   }
 
   /**
@@ -283,6 +279,25 @@ class KnockKnock {
    */
   hasNext() {
     return this._stack.length > 0 && (this._options.limit == null || this._options.limit > this._callers.length)
+  }
+
+  /**
+   * Caputes the call stack for this {@link KnockKnock}.
+   *
+   * The first 3 frames are excluded from the stack as these will always relate to either this module (i.e.
+   * <code>knockknock.js</code>). All frames at the start of the remaining stack that originated from the same file are
+   * also then excluded as these will be internal from the module that is trying to find its callers. The
+   * <code>offset</code> option is then applied on top of this.
+   *
+   * @return {CallSite[]} The captured call stack.
+   * @private
+   */
+  _getStack() {
+    const stack = getStack().slice(3)
+    const originatorFilePath = stack[0].getFileName()
+    const startIndex = stack.findIndex((frame) => frame.getFileName() !== originatorFilePath)
+
+    return stack.slice(startIndex + this._options.offset)
   }
 
   /**

--- a/src/knockknock.js
+++ b/src/knockknock.js
@@ -174,7 +174,8 @@ class KnockKnock {
       excludes,
       filterFiles: options.filterFiles,
       filterPackages: options.filterPackages,
-      limit: options.limit != null ? Math.max(0, options.limit) : null
+      limit: options.limit != null ? Math.max(0, options.limit) : null,
+      offset: options.offset != null ? Math.max(0, options.offset) : 0
     }
   }
 
@@ -218,12 +219,13 @@ class KnockKnock {
      * The call stack captured by this {@link KnockKnock}.
      *
      * The first 3 frames are excluded from the stack as these will always relate to either this module (i.e.
-     * <code>knockknock.js</code>) or the module that is trying to determine its caller.
+     * <code>knockknock.js</code>) or the module that is trying to determine its caller. The <code>offset</cod> option
+     * is then applied on top of this.
      *
      * @private
      * @type {CallSite[]}
      */
-    this._stack = getStack().slice(3)
+    this._stack = getStack().slice(3 + this._options.offset)
   }
 
   /**
@@ -503,4 +505,5 @@ module.exports.version = version
  * <code>excludes</code>.
  * @property {number} [limit] - The maximum number of callers to be included in the results. Information for all
  * filtered callers will be included if this is <code>null</code>.
+ * @property {number} [offset=0] - The number of frames from the call stack to be skipped initially.
  */

--- a/src/knockknock.js
+++ b/src/knockknock.js
@@ -32,7 +32,7 @@ const version = require('../package.json').version
 /**
  * A cache containing packages mapped to file paths.
  *
- * The intension of this cache is to speed up package lookups for repeat callers by avoiding file system traversal.
+ * The intention of this cache is to speed up package lookups for repeat callers by avoiding file system traversal.
  *
  * @private
  * @type {Map.<string, knockknock~Package>}
@@ -40,20 +40,22 @@ const version = require('../package.json').version
 const packageCache = new Map()
 
 /**
- * Analyzes each frame in the call stack to find as much information about the caller as possible.
+ * Analyzes each frame in the call stack, finds out as much information about the callers as possible, and filters out
+ * any unwanted information.
  *
  * @private
  */
-class Finder {
+class KnockKnock {
 
   /**
-   * Generates the caller information by combining the specified <code>filePath</code> with the <code>pkg</code> and
-   * stack <code>frame</code> information provided.
+   * Builds the caller information based on the specified <code>filePath</code> with the information within the package
+   * and stack <code>frame</code> provided.
    *
    * @param {string} filePath - the path of the caller file
-   * @param {knockknock~Package} pkg - the information for the caller's package
-   * @param {CallSite} frame - the current stack frame
-   * @return {knockknock~Caller} The combined caller information.
+   * @param {?knockknock~Package} pkg - the caller's package information (may be <code>null</code> if the caller file
+   * does not exist within a package)
+   * @param {CallSite} frame - the current call stack frame being processed
+   * @return {knockknock~Caller} The collected caller information.
    * @private
    * @static
    */
@@ -69,16 +71,16 @@ class Finder {
 
   /**
    * Asynchronously finds the first parent directory of the specified <code>filePath</code> that contains a
-   * <code>package.json</code> file and then returns it to the <code>callback</code> function provided.
+   * <code>package.json</code> file and passes it to the <code>callback</code> function provided.
    *
    * This method returns a <code>Promise</code> chained using the <code>callback</code> function so that it can be
-   * returned by {@link Finder#findNext}. The <code>Promise</code> is resolved with <code>null</code> if no package
-   * directory could be found.
+   * returned by {@link KnockKnock#find}.
    *
    * @param {string} filePath - the path of the file whose package directory is to be found
    * @param {knockknock~FindPackageDirectoryCallback} callback - the function to be called with the path of the package
    * directory
-   * @return {Promise.<Error, knockknock~Caller>} The result of calling <code>callback</code>.
+   * @return {Promise.<Error, knockknock~Caller[]>} A <code>Promise</code> chained on to the result of calling
+   * <code>callback</code>.
    * @private
    * @static
    */
@@ -91,13 +93,12 @@ class Finder {
    * <code>package.json</code> file and passes it to the <code>callback</code> function provided.
    *
    * This method returns the return value of the <code>callback</code> function so that it can be returned by
-   * {@link Finder#findNext}. <code>null</code> is returned if no package directory could be found.
+   * {@link KnockKnock#find}.
    *
    * @param {string} filePath - the path of the file whose package directory is to be found
    * @param {knockknock~FindPackageDirectoryCallback} callback - the function to be called with the path of the package
    * directory
-   * @return {?knockknock~Caller} The result of calling <code>callback</code> or <code>null</code> if no package
-   * directory was found.
+   * @return {knockknock~Caller[]} The result of calling <code>callback</code>.
    * @private
    * @static
    */
@@ -106,10 +107,13 @@ class Finder {
   }
 
   /**
-   * Returns the information for the package installed at the specified directory path.
+   * Returns the information for the package installed in the directory at the path provided.
    *
-   * This information contains <code>dirPath</code> as well as the <code>name</code>, <code>version</code>, and the
-   * <code>main</code> file (absolute) read from the <code>package.json</code> file.
+   * This information contains <code>dirPath</code> as well as the <code>name</code>, <code>version</code>, and
+   * (absolute) path of the <code>main</code> file (if any) read from the <code>package.json</code> file.
+   *
+   * This method should only be called when it is known that <code>dirPath</code> contains a <code>package.json</code>
+   * file.
    *
    * @param {string} dirPath - the path of the installation directory for the package whose information is to be
    * returned
@@ -133,10 +137,9 @@ class Finder {
   /**
    * Returns whether the specified <code>filePath</code> is internal.
    *
-   * A file is considered to be internal if it is either this module (i.e. <code>knockknock.js</code>) or is not
-   * absolute. The latter case is a quick and dirty way of identifying Node.js internal files as they are not given
-   * absolute file paths in stack traces, without the need for a call to <code>fs</code> to determine whether the file
-   * actually exists in the current working directory.
+   * A file is considered to be internal if it is either this module (i.e. <code>knockknock.js</code>) or if the path is
+   * not absolute. The latter case is a quick and dirty way of identifying Node.js internal files as they are only ever
+   * given relative file paths in stack traces.
    *
    * @param {string} filePath - the path of the file to be checked
    * @return {boolean} <code>true</code> if <code>filePath</code> is internal; otherwise <code>false</code>.
@@ -148,12 +151,12 @@ class Finder {
   }
 
   /**
-   * Parses the optional input <code>options</code> provided, normalizing options and applying default values where
+   * Parses the optional input <code>options</code> provided, normalizing options and applying default values, where
    * needed.
    *
    * @param {?knockknock~Options} options - the input options to be parsed (may be <code>null</code> if none were
    * provided)
-   * @return {knockknock~Options} A new options object based on <code>options</code>.
+   * @return {knockknock~Options} A new options object parsed from <code>options</code>.
    * @private
    * @static
    */
@@ -170,24 +173,49 @@ class Finder {
     return {
       excludes,
       filterFiles: options.filterFiles,
-      filterPackages: options.filterPackages
+      filterPackages: options.filterPackages,
+      limit: options.limit != null ? Math.max(0, options.limit) : null
     }
   }
 
   /**
-   * Creates an instance of {@link Finder} using the optional <code>options</code> provided.
+   * Creates an instance of {@link KnockKnock} using the optional <code>options</code> provided.
    *
    * <code>sync</code> can be used to control whether package directory searches are performed synchronously or
    * asynchronously.
    *
-   * @param {boolean} [sync] - <code>true</code> if package directory searches should be synchronous or
-   * <code>false</code> if they should be asynchronous (may be <code>null</code>)
-   * @param {knockknock~Options} [options] - the optional options to be used (may be <code>null</code>)
+   * @param {boolean} sync - <code>true</code> if package directory searches should be synchronous or <code>false</code>
+   * if they should be asynchronous
+   * @param {knockknock~Options} [options] - the options to be used (may be <code>null</code>)
    * @public
    */
   constructor(sync, options) {
     /**
-     * The call stack captured by this {@link Finder}.
+     * Whether package directory searches initiated by this {@link KnockKnock} should be made synchronously.
+     *
+     * @private
+     * @type {boolean}
+     */
+    this._sync = sync
+
+    /**
+     * The parsed options for this {@link KnockKnock}.
+     *
+     * @private
+     * @type {knockknock~Options}
+     */
+    this._options = KnockKnock._parseOptions(options)
+
+    /**
+     * The information for all filtered callers found by this {@link KnockKnock}.
+     *
+     * @private
+     * @type {knockknock~Caller[]}
+     */
+    this._callers = []
+
+    /**
+     * The call stack captured by this {@link KnockKnock}.
      *
      * The first 3 frames are excluded from the stack as these will always relate to either this module (i.e.
      * <code>knockknock.js</code>) or the module that is trying to determine its caller.
@@ -196,111 +224,102 @@ class Finder {
      * @type {CallSite[]}
      */
     this._stack = getStack().slice(3)
-
-    /**
-     * The parsed options for this {@link Finder}.
-     *
-     * @private
-     * @type {knockknock~Options}
-     */
-    this._options = Finder._parseOptions(options)
-
-    /**
-     * Whether package directory searches initiated by this {@link Finder} should be made synchronously.
-     *
-     * @private
-     * @type {boolean}
-     */
-    this._sync = sync
   }
 
   /**
-   * Removes the first frame from the call stack of this {@link Finder} and attempts to find information on the file
-   * responsible for that call as well as the package that owns it.
+   * Removes the next frame from the call stack of this {@link KnockKnock} and attempts to find information on the file
+   * responsible for that call as well as the package that owns it and stores that information to be returned once no
+   * more callers are to be inspected.
    *
-   * If there are no more frames in the call stack then this method will return <code>null</code>. If the file
-   * responsible for the call but no package could be found for the responsible file, then the caller information will
-   * only include the path of the file.
+   * If there are no more frames in the call stack or if the limit of callers has been reached, then this method will
+   * return all callers found up until now.
    *
-   * This method will directly return the caller information if this {@link Finder} is synchronous. Otherwise, this
-   * method will return a <code>Promise</code> which will be resolved with the caller information once it has been
-   * found.
+   * This method will directly return the information for all filtered callers if this {@link KnockKnock} is
+   * synchronous. Otherwise, this method will return a <code>Promise</code> which will be resolved with the information
+   * for all filtered callers once they have been found.
    *
-   * @return {?knockknock~Caller|Promise.<Error, knockknock~Caller>} The caller information (or a <code>Promise</code>
-   * resolved with it when asynchronous) or <code>null</code> if there are no more frames in the call stack.
+   * @return {knockknock~Caller[]|Promise.<Error, knockknock~Caller[]>} The information for all filtered callers (or a
+   * <code>Promise</code> resolved with them when asynchronous).
    * @public
    */
-  findNext() {
-    const frame = this._stack.shift()
-    if (!frame) {
-      debug('Unable to find calling package')
-
-      return null
+  find() {
+    if (!this.hasNext()) {
+      return this._callers
     }
 
+    const frame = this._stack.shift()
     const filePath = frame.getFileName()
-    if (Finder._isInternal(filePath)) {
+
+    if (KnockKnock._isInternal(filePath)) {
       debug('Skipping call from internal file: %s', filePath)
 
-      return this.findNext()
+      return this.find()
     }
 
     if (packageCache.has(filePath)) {
-      return this._handlePackage(packageCache.get(filePath), filePath, frame)
+      return this._handleFile(filePath, packageCache.get(filePath), frame)
     }
 
     debug('Attempting to find installation directory for package containing file: %s', filePath)
 
-    const packageDirFinder = Finder[this._sync ? '_findPackageDirectorySync' : '_findPackageDirectory']
+    const packageDirFinder = KnockKnock[this._sync ? '_findPackageDirectorySync' : '_findPackageDirectory']
     return packageDirFinder(filePath, (dirPath) => {
-      const pkg = dirPath != null ? Finder._getPackage(dirPath) : null
+      const pkg = dirPath != null ? KnockKnock._getPackage(dirPath) : null
 
       packageCache.set(filePath, pkg)
 
-      return this._handlePackage(pkg, filePath, frame)
+      return this._handleFile(filePath, pkg, frame)
     })
   }
 
   /**
-   * Handles the specified package containing the <code>filePath</code> provided.
+   * Returns whether this {@link KnockKnock} can return any further caller information.
+   *
+   * @return {boolean} <code>true</code> if more caller information can be extracted from the call stack; otherwise
+   * <code>false</code>.
+   * @public
+   */
+  hasNext() {
+    return this._stack.length > 0 && (this._options.limit == null || this._options.limit > this._callers.length)
+  }
+
+  /**
+   * Handles the call from the specified <code>filePath</code>.
    *
    * <code>pkg</code> will be <code>null</code> if no parent package could be found for <code>filePath</code>, in which
-   * case this method will return the caller information without the package information.
+   * case the caller information will not include any package information.
    *
-   * If <code>pkg</code> has been excluded, this method will call {@link Finder#findNext} to try and find the
-   * information for the next caller and, as such, shares the same return values. Otherwise, this method will return the
-   * caller information complete with details on the containing package.
+   * If <code>filePath</code> or <code>pkg</code> has been excluded, the stack <code>frame</code> being processed will
+   * be skipped and this method will call {@link KnockKnock#find} to try and find the information for the next caller
+   * and, as such, shares the same return values. Otherwise, the complete information for the calling file (and possibly
+   * package) will be included in the results for this {@link KnockKnock}.
    *
    * The given stack <code>frame</code> is used to build the caller information, where necessary.
    *
-   * @param {?knockknock~Package} pkg - the information for the package responsible for the current call in the stack
+   * @param {string} filePath - the path of the file responsible for the current call being processed
+   * @param {?knockknock~Package} pkg - the information for the package responsible for the current call being processed
    * (may be <code>null</code> if none could be found)
-   * @param {string} filePath - the path of the file responsible for the current call in the stack
-   * @param {CallSite} frame - the current stack frame
-   * @return {?knockknock~Caller|Promise.<Error, knockknock~Caller>} The caller information (or a <code>Promise</code>
-   * resolved with it when asynchronous) or <code>null</code> if there are no more frames in the call stack.
+   * @param {CallSite} frame - the current stack frame being processed
+   * @return {knockknock~Caller[]|Promise.<Error, knockknock~Caller[]>} The information for all filtered callers (or a
+   * <code>Promise</code> resolved with them when asynchronous).
    * @private
    */
-  _handlePackage(pkg, filePath, frame) {
+  _handleFile(filePath, pkg, frame) {
     if (pkg == null) {
       debug('Unable to find package containing file: %s', filePath)
-
-      return Finder._buildCaller(filePath, null, frame)
+    } else {
+      debug('Found package "%s" containing file: %s', pkg.name, filePath)
     }
-
-    debug('Found package "%s" containing file: %s', pkg.name, filePath)
 
     if (!this._isPackageIncluded(pkg)) {
-      debug('Skipping call within package "%s" from file: %s', pkg.name, filePath)
-
-      return this.findNext()
+      debug('Skipping call within package %s from file: %s', pkg ? `"${pkg.name}"` : '<unknown>', filePath)
     } else if (!this._isFileIncluded(filePath)) {
       debug('Skipping call from file: %s', filePath)
-
-      return this.findNext()
+    } else {
+      this._callers.push(KnockKnock._buildCaller(filePath, pkg, frame))
     }
 
-    return Finder._buildCaller(filePath, pkg, frame)
+    return this.find()
   }
 
   /**
@@ -308,8 +327,8 @@ class Finder {
    *
    * This is determined using the runtime options that were passed in.
    *
-   * @param {string} filePath - the path of the file responsible for the current call in the stack
-   * @return {boolean} <code>true</code> if the call from <code>filePath</code> should be included; otherwise
+   * @param {string} filePath - the path of the file responsible for the current call being processed
+   * @return {boolean} <code>true</code> if a call from <code>filePath</code> should be included; otherwise
    * <code>false</code>.
    * @private
    */
@@ -322,48 +341,52 @@ class Finder {
    *
    * This is determined using the runtime options that were passed in.
    *
-   * @param {?knockknock~Package} pkg - the information for the package responsible for the current call in the stack
+   * @param {?knockknock~Package} pkg - the information for the package responsible for the current call being processed
    * (may be <code>null</code> if none could be found)
-   * @return {boolean} <code>true</code> if the call from within <code>pkg</code> should be included; otherwise
+   * @return {boolean} <code>true</code> if a call from within <code>pkg</code> should be included; otherwise
    * <code>false</code>.
    * @private
    */
   _isPackageIncluded(pkg) {
-    // TODO: #7 Only perform this check when pkg is not null
-    if (this._options.excludes.indexOf(pkg.name) >= 0) {
+    if (pkg && this._options.excludes.indexOf(pkg.name) >= 0) {
       return false
     }
 
-    return !this._options.filterPackages || this._options.filterPackages(Object.assign({}, pkg))
+    return !this._options.filterPackages || this._options.filterPackages(pkg ? Object.assign({}, pkg) : null)
   }
 
 }
 
 /**
- * Generates a call stack and analyzes each frame to find as much information as possible on the file responsible for
- * calling the code that invoked this method.
+ * Generates a call stack and analyzes each frame to find out as much information as possible on the files responsible
+ * for calling the module that invoked this method.
  *
- * This information includes the path of the file responsible as well as some basic information on the package it is
- * contained within, where applicable. The package information is retrieved from its <code>package.json</code> file
- * <b>asynchronously</b>.
+ * This information includes the path of the file responsible for each call as well as some basic information on the
+ * package it is contained within, where applicable. The package information is retrieved from its
+ * <code>package.json</code> file <b>asynchronously</b>. Other information about the call is included as well.
  *
  * Calls made internally from within knockknock and Node.js are always ignored and calls from within specific packages
- * can be excluded via <code>options.excludes</code>. The returned <code>Promise</code> will be resolved with
- * <code>null</code> if no call could be found or all calls were skipped for reasons just mentioned.
+ * can be excluded via <code>options.excludes</code> and/or <code>options.filterPackages</code>. Exclusions can even be
+ * specific to files via <code>options.filterFiles</code>. The returned <code>Promise</code> will be resolved with the
+ * information for all filter callers.
+ *
+ * The maximum number of callers resolved can be controlled via <code>options.limit</code>.
  *
  * @param {knockknock~Options} [options] - the options to be used (may be <code>null</code>)
- * @return {Promise.<Error, knockknock~Caller>} A <code>Promise</code> for retrieving the information for the caller of
- * the request origin, which may be <code>null</code> if none could be found.
+ * @return {Promise.<Error, knockknock~Caller[]>} A <code>Promise</code> for retrieving the information for all filtered
+ * callers of the request origin.
  * @public
  * @static
  */
 module.exports = function whoIsThere(options) {
-  return Promise.resolve(new Finder(false, options).findNext())
+  return Promise.resolve(new KnockKnock(false, options).find())
 }
 
 /**
  * Clears the cache containing packages mapped to file paths which is used to speed up package lookups for repeat
  * callers by avoiding file system traversal.
+ *
+ * This is primarily intended for testing purposes.
  *
  * @return {void}
  * @protected
@@ -374,25 +397,27 @@ module.exports.clearCache = function clearCache() {
 }
 
 /**
- * Generates a call stack and analyzes each frame to find as much information as possible on the file responsible for
- * calling the code that invoked this method.
+ * Generates a call stack and analyzes each frame to find out as much information as possible on the files responsible
+ * for calling the module that invoked this method.
  *
- * This information includes the path of the file responsible as well as some basic information on the package it is
- * contained within, where applicable. The package information is retrieved from its <code>package.json</code> file
- * <b>synchronously</b>.
+ * This information includes the path of the file responsible for each call as well as some basic information on the
+ * package it is contained within, where applicable. The package information is retrieved from its
+ * <code>package.json</code> file <b>synchronously</b>. Other information about the call is included as well.
  *
  * Calls made internally from within knockknock and Node.js are always ignored and calls from within specific packages
- * can be excluded via <code>options.excludes</code>. This method will return <code>null</code> if no call could be
- * found or all calls were skipped for reasons just mentioned.
+ * can be excluded via <code>options.excludes</code> and/or <code>options.filterPackages</code>. Exclusions can even be
+ * specific to files via <code>options.filterFiles</code>. This method will return the information for all filtered
+ * callers.
+ *
+ * The maximum number of callers returned can be controlled via <code>options.limit</code>.
  *
  * @param {knockknock~Options} [options] - the options to be used (may be <code>null</code>)
- * @return {?knockknock~Caller} The information for the caller of the request origin or <code>null</code> if none could
- * be found.
+ * @return {knockknock~Caller[]} The information for all filtered callers of the request origin.
  * @public
  * @static
  */
 module.exports.sync = function whoIsThereSync(options) {
-  return new Finder(true, options).findNext()
+  return new KnockKnock(true, options).find()
 }
 
 /**
@@ -405,25 +430,25 @@ module.exports.sync = function whoIsThereSync(options) {
 module.exports.version = version
 
 /**
- * Called with path of the current file that is being processed to allow consumers to make a decision on whether the
- * file is to be included.
+ * Called with path of the file responsible for the current call that is being processed to allow consumers to make a
+ * decision on whether the file is to be included.
  *
  * @callback knockknock~FilterFilesCallback
- * @param {string} filePath - the path of the current file being processed
+ * @param {string} filePath - the path of the file responsible for the current call being processed
  * @return {boolean} <code>true</code> to include calls originating from <code>filePath</code>; otherwise
  * <code>false</code>.
  */
 
 /**
- * Called with the information for the package containing the current file that is being processed to allow consumers to
- * make a decision on whether files within the specified package are to be included.
+ * Called with the information for the package containing the file responsible for the current call that is being
+ * processed to allow consumers to make a decision on whether files within the specified package are to be included.
  *
- * If the current file being processed does not belong to a package, then the decision returned will apply to <b>all</b>
- * unpackaged files.
+ * If the file responsible for the current call being processed does not belong to a package, then the decision returned
+ * will apply to <b>all</b> unpackaged files.
  *
  * @callback knockknock~FilterPackagesCallback
- * @param {?knockknock~Package} pkg - the package information for the current file being processed (may be
- * <code>null</code> if no package was found)
+ * @param {?knockknock~Package} pkg - the package information for the file responsible for the current call being
+ * processed (may be <code>null</code> if no package was found)
  * @return {boolean} <code>true</code> to include calls originating from files within the package (or all unpackaged
  * files, if <code>pkg</code> is <code>null</code>); otherwise <code>false</code>.
  */
@@ -434,21 +459,23 @@ module.exports.version = version
  * @callback knockknock~FindPackageDirectoryCallback
  * @param {?string} dirPath - the path to the package installation directory (may be <code>null</code> if none could be
  * found)
- * @return {?knockknock~Caller|Promise.<Error, knockknock~Caller>} The caller information (or a <code>Promise</code>
- * resolved with it when asynchronous) or <code>null</code> if there are no more frames in the call stack.
+ * @return {knockknock~Caller[]|Promise.<Error, knockknock~Caller[]>} The information for all filtered callers (or a
+ * <code>Promise</code> resolved with them when asynchronous).
  */
 
 /**
- * Contains information for the caller of the origin.
+ * Contains information for a caller of the request origin.
  *
- * Information about the package containing the file responsible for calling the origin is only included where possible.
+ * Information about the package containing the file responsible for calling the origin is only included where
+ * applicable.
  *
  * @typedef {Object} knockknock~Caller
- * @property {string} file - The path of the file responsible for calling the origin.
- * @property {number} line - The line number within <code>file</code> that was responsible for calling the origin.
- * @property {string} name - The name of the function within <code>file</code> that was responsible for calling the
- * origin or <code>&lt;anonymous&gt;</code> if the function was anonymous.
- * @property {?knockknock~Package} package - The information for the package responsible for calling the origin (may be
+ * @property {number} column - The column number within <code>file</code> that was responsible for the call.
+ * @property {string} file - The path of the file responsible for the call.
+ * @property {number} line - The line number within <code>file</code> that was responsible for the call.
+ * @property {string} name - The name of the function within <code>file</code> that was responsible for the call or
+ * <code>&lt;anonymous&gt;</code> if the function was anonymous.
+ * @property {?knockknock~Package} package - The information for the package responsible for the call (may be
  * <code>null</code> if no package could be found).
  */
 
@@ -464,14 +491,16 @@ module.exports.version = version
  */
 
 /**
- * The options to be used to find the caller of the origin.
+ * The options to be used to find the callers of the request origin.
  *
  * @typedef {Object} knockknock~Options
  * @property {string|string[]} [excludes] - The names of packages whose calls should be ignored when trying to find the
- * caller.
+ * callers.
  * @property {knockknock~FilterFilesCallback} [filterFiles] - A function to be called to filter files based on their
  * path. This is only called for files contained within included packages (if any).
  * @property {knockknock~FilterPackagesCallback} [filterPackages] - A function to be called to filter files based on the
  * package to which they belong (if any). This is only called for packages whose names are not listed in
  * <code>excludes</code>.
+ * @property {number} [limit] - The maximum number of callers to be included in the results. Information for all
+ * filtered callers will be included if this is <code>null</code>.
  */

--- a/src/knockknock.js
+++ b/src/knockknock.js
@@ -59,6 +59,7 @@ class Finder {
    */
   static _buildCaller(descriptor, filePath, frame) {
     return {
+      column: frame.getColumnNumber(),
       file: filePath,
       line: frame.getLineNumber(),
       name: frame.getFunctionName() || '<anonymous>',

--- a/test/fixtures/circular/package.json
+++ b/test/fixtures/circular/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "circular",
+  "version": "0.0.1",
+  "main": "src/circular.js",
+  "private": true
+}

--- a/test/fixtures/circular/src/bar.js
+++ b/test/fixtures/circular/src/bar.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use strict'
+
+module.exports = function circularBarFunction(options) {
+  return require('./circular').circular(options)
+}
+module.exports.sync = function circularBarSyncFunction(options) {
+  return require('./circular').circular.sync(options)
+}

--- a/test/fixtures/circular/src/circular.js
+++ b/test/fixtures/circular/src/circular.js
@@ -30,6 +30,7 @@ module.exports = function circularFunction(options) {
 module.exports.sync = function circularSyncFunction(options) {
   return require('./foo').sync(options)
 }
+
 module.exports.circular = function circularCircularFunction(options) {
   return whoIsThere(options)
 }

--- a/test/fixtures/circular/src/circular.js
+++ b/test/fixtures/circular/src/circular.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use strict'
+
+const whoIsThere = require('../../../../src/knockknock')
+
+module.exports = function circularFunction(options) {
+  return require('./foo')(options)
+}
+module.exports.sync = function circularSyncFunction(options) {
+  return require('./foo').sync(options)
+}
+module.exports.circular = function circularCircularFunction(options) {
+  return whoIsThere(options)
+}
+module.exports.circular.sync = function circularCircularSyncFunction(options) {
+  return whoIsThere.sync(options)
+}

--- a/test/fixtures/circular/src/foo.js
+++ b/test/fixtures/circular/src/foo.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use strict'
+
+module.exports = function circularFooFunction(options) {
+  return require('./bar')(options)
+}
+module.exports.sync = function circularFooSyncFunction(options) {
+  return require('./bar').sync(options)
+}

--- a/test/fixtures/internal/src/foo.js
+++ b/test/fixtures/internal/src/foo.js
@@ -22,11 +22,15 @@
 
 'use strict'
 
+/* eslint "func-names": "off", "no-extra-parens": "off" */
+
 const whoIsThere = require('../../../../src/knockknock')
 
 module.exports = function fooFunction(options) {
-  return whoIsThere(options)
+  return (() => whoIsThere(options))()
 }
 module.exports.sync = function fooSyncFunction(options) {
-  return whoIsThere.sync(options)
+  return (function() {
+    return whoIsThere.sync(options)
+  }())
 }

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -38,12 +38,9 @@ exports.createOptions = function createOptions(options) {
     options = {}
   }
 
-  let excludes = [ 'mocha' ]
-  if (options.excludes) {
-    excludes = excludes.concat(options.excludes)
-  }
+  options.excludes = [ 'mocha' ].concat(options.excludes || [])
 
-  return { excludes }
+  return options
 }
 
 /**

--- a/test/knockknock.circular.spec.js
+++ b/test/knockknock.circular.spec.js
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2017 Alasdair Mercer, Skelp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+'use strict'
+
+const expect = require('chai').expect
+const path = require('path')
+
+const circular = require('./fixtures/circular/src/circular')
+const helpers = require('./helpers')
+const knockknock = require('../src/knockknock')
+
+describe('knockknock:fixture:circular', () => {
+  context('when asynchronous', () => {
+    before(() => knockknock.clearCache())
+
+    it('should return promise for caller & package information for fixture file', () => {
+      return circular(helpers.createOptions())
+        .then((caller) => {
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 32,
+            file: 'circular/src/bar.js',
+            line: 26,
+            name: 'circularBarFunction',
+            package: {
+              directory: 'circular',
+              main: 'circular/src/circular.js',
+              name: 'circular',
+              version: '0.0.1'
+            }
+          }))
+        })
+    })
+
+    context('and file is excluded via "filterFiles"', () => {
+      it('should return promise for caller & package information for "knocking" file', () => {
+        return circular(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'bar.js' }))
+          .then((caller) => {
+            expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 26,
+              file: 'circular/src/foo.js',
+              line: 26,
+              name: 'circularFooFunction',
+              package: {
+                directory: 'circular',
+                main: 'circular/src/circular.js',
+                name: 'circular',
+                version: '0.0.1'
+              }
+            }))
+          })
+      })
+    })
+
+    context('and both file and "knocking" file is excluded via "filterFiles"', () => {
+      it('should return promise for caller & package information for original "knocking" file', () => {
+        return circular(helpers.createOptions({
+          filterFiles: (filePath) => {
+            return [ 'bar.js', 'foo.js' ].indexOf(path.basename(filePath)) < 0
+          }
+        }))
+          .then((caller) => {
+            expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 26,
+              file: 'circular/src/circular.js',
+              line: 28,
+              name: 'circularFunction',
+              package: {
+                directory: 'circular',
+                main: 'circular/src/circular.js',
+                name: 'circular',
+                version: '0.0.1'
+              }
+            }))
+          })
+      })
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return promise for null', () => {
+        return circular(helpers.createOptions({ filterFiles: () => false }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and package is excluded via "excludes"', () => {
+      it('should return promise for null', () => {
+        return circular(helpers.createOptions({ excludes: 'circular' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return promise for null', () => {
+        return circular(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'circular' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+  })
+
+  context('when synchronous', () => {
+    before(() => knockknock.clearCache())
+
+    it('should return caller & package information for fixture file', () => {
+      const caller = circular.sync(helpers.createOptions())
+
+      expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        column: 41,
+        file: 'circular/src/bar.js',
+        line: 29,
+        name: 'circularBarSyncFunction',
+        package: {
+          directory: 'circular',
+          main: 'circular/src/circular.js',
+          name: 'circular',
+          version: '0.0.1'
+        }
+      }))
+    })
+
+    context('and file is excluded via "filterFiles"', () => {
+      it('should return caller & package information for "knocking" file', () => {
+        const caller = circular.sync(helpers.createOptions({
+          filterFiles: (filePath) => {
+            return path.basename(filePath) !== 'bar.js'
+          }
+        }))
+
+        expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 27,
+          file: 'circular/src/foo.js',
+          line: 29,
+          name: 'circularFooSyncFunction',
+          package: {
+            directory: 'circular',
+            main: 'circular/src/circular.js',
+            name: 'circular',
+            version: '0.0.1'
+          }
+        }))
+      })
+    })
+
+    context('and both file and "knocking" file is excluded via "filterFiles"', () => {
+      it('should return caller & package information for original "knocking" file', () => {
+        const caller = circular.sync(helpers.createOptions({
+          filterFiles: (filePath) => {
+            return [ 'bar.js', 'foo.js' ].indexOf(path.basename(filePath)) < 0
+          }
+        }))
+
+        expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 27,
+          file: 'circular/src/circular.js',
+          line: 31,
+          name: 'circularSyncFunction',
+          package: {
+            directory: 'circular',
+            main: 'circular/src/circular.js',
+            name: 'circular',
+            version: '0.0.1'
+          }
+        }))
+      })
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return null', () => {
+        const caller = circular.sync(helpers.createOptions({ filterFiles: () => false }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and package is excluded via "excludes"', () => {
+      it('should return null', () => {
+        const caller = circular.sync(helpers.createOptions({ excludes: 'circular' }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return null', () => {
+        const caller = circular.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'circular' }))
+
+        expect(caller).to.be.null
+      })
+    })
+  })
+})

--- a/test/knockknock.circular.spec.js
+++ b/test/knockknock.circular.spec.js
@@ -76,6 +76,39 @@ describe('knockknock:fixture:circular', () => {
         })
     })
 
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for callers (incl. package) before file before "knocking" file', () => {
+        return circular(helpers.createOptions({ offset: 1 }))
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(2)
+            expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 26,
+              file: 'circular/src/foo.js',
+              line: 26,
+              name: 'circularFooFunction',
+              package: {
+                directory: 'circular',
+                main: 'circular/src/circular.js',
+                name: 'circular',
+                version: '0.0.1'
+              }
+            }))
+            expect(callers[1]).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 26,
+              file: 'circular/src/circular.js',
+              line: 28,
+              name: 'circularFunction',
+              package: {
+                directory: 'circular',
+                main: 'circular/src/circular.js',
+                name: 'circular',
+                version: '0.0.1'
+              }
+            }))
+          })
+      })
+    })
+
     context('and limited to a single caller via "limit"', () => {
       it('should return promise for only caller (incl. package) before "knocking" file', () => {
         return circular(helpers.createOptions({ limit: 1 }))
@@ -226,6 +259,38 @@ describe('knockknock:fixture:circular', () => {
           version: '0.0.1'
         }
       }))
+    })
+
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for callers (incl. package) before file before "knocking" file', () => {
+        const callers = circular.sync(helpers.createOptions({ offset: 1 }))
+
+        expect(callers).to.have.lengthOf(2)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 27,
+          file: 'circular/src/foo.js',
+          line: 29,
+          name: 'circularFooSyncFunction',
+          package: {
+            directory: 'circular',
+            main: 'circular/src/circular.js',
+            name: 'circular',
+            version: '0.0.1'
+          }
+        }))
+        expect(callers[1]).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 27,
+          file: 'circular/src/circular.js',
+          line: 31,
+          name: 'circularSyncFunction',
+          package: {
+            directory: 'circular',
+            main: 'circular/src/circular.js',
+            name: 'circular',
+            version: '0.0.1'
+          }
+        }))
+      })
     })
 
     context('and limited to a single caller via "limit"', () => {

--- a/test/knockknock.flat.spec.js
+++ b/test/knockknock.flat.spec.js
@@ -51,9 +51,18 @@ describe('knockknock:fixture:flat', () => {
           })
       })
 
-      context('and package is excluded', () => {
+      context('and file package is excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return flat.foo(helpers.createOptions({ excludes: 'flat' }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and file package is excluded via "filterPackages"', () => {
+        it('should return promise for null', () => {
+          return flat.foo(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
             .then((caller) => {
               expect(caller).to.be.null
             })
@@ -80,7 +89,7 @@ describe('knockknock:fixture:flat', () => {
           })
       })
 
-      context('and "knocking" package is excluded', () => {
+      context('and "knocking" package is excluded via "excludes"', () => {
         it('should return promise for caller & package information for fixture file', () => {
           return flat.bar(helpers.createOptions({ excludes: 'bar' }))
             .then((caller) => {
@@ -100,7 +109,27 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and package is excluded', () => {
+      context('and "knocking" package is excluded via "filterPackages"', () => {
+        it('should return promise for caller & package information for fixture file', () => {
+          return flat.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
+            .then((caller) => {
+              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'flat/src/flat.js',
+                line: 29,
+                name: 'flatBarFunction',
+                package: {
+                  directory: 'flat',
+                  main: 'flat/src/flat.js',
+                  name: 'flat',
+                  version: '1.0.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and file package is excluded via "excludes"', () => {
         it('should return promise for caller & package information for indirect fixture file', () => {
           return flat.bar(helpers.createOptions({ excludes: 'flat' }))
             .then((caller) => {
@@ -120,9 +149,38 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded', () => {
+      context('and file package is excluded via "filterPackages"', () => {
+        it('should return promise for caller & package information for indirect fixture file', () => {
+          return flat.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
+            .then((caller) => {
+              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'flat/node_modules/bar/src/bar.js',
+                line: 28,
+                name: 'barFunction',
+                package: {
+                  directory: 'flat/node_modules/bar',
+                  main: 'flat/node_modules/bar/src/bar.js',
+                  name: 'bar',
+                  version: '1.1.2'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return flat.bar(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+        it('should return promise for null', () => {
+          return flat.bar(helpers.createOptions({ filterPackages: (pkg) => [ 'bar', 'flat' ].indexOf(pkg.name) < 0 }))
             .then((caller) => {
               expect(caller).to.be.null
             })
@@ -152,9 +210,17 @@ describe('knockknock:fixture:flat', () => {
         }))
       })
 
-      context('and package is excluded', () => {
+      context('and package is excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = flat.foo.sync(helpers.createOptions({ excludes: 'flat' }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and package is excluded via "filterPackages"', () => {
+        it('should return null', () => {
+          const caller = flat.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
 
           expect(caller).to.be.null
         })
@@ -179,7 +245,7 @@ describe('knockknock:fixture:flat', () => {
         }))
       })
 
-      context('and "knocking" package is excluded', () => {
+      context('and "knocking" package is excluded via "excludes"', () => {
         it('should return caller & package information for fixture file', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: 'bar' }))
 
@@ -198,7 +264,26 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and package is excluded', () => {
+      context('and "knocking" package is excluded via "filterPackages"', () => {
+        it('should return caller & package information for fixture file', () => {
+          const caller = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
+
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'flat/src/flat.js',
+            line: 32,
+            name: 'flatBarSyncFunction',
+            package: {
+              directory: 'flat',
+              main: 'flat/src/flat.js',
+              name: 'flat',
+              version: '1.0.1'
+            }
+          }))
+        })
+      })
+
+      context('and package is excluded via "excludes"', () => {
         it('should return caller & package information for indirect fixture file', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: 'flat' }))
 
@@ -217,9 +302,40 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded', () => {
+      context('and package is excluded via "filterPackages"', () => {
+        it('should return caller & package information for indirect fixture file', () => {
+          const caller = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
+
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'flat/node_modules/bar/src/bar.js',
+            line: 31,
+            name: 'barSyncFunction',
+            package: {
+              directory: 'flat/node_modules/bar',
+              main: 'flat/node_modules/bar/src/bar.js',
+              name: 'bar',
+              version: '1.1.2'
+            }
+          }))
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+        it('should return null', () => {
+          const caller = flat.bar.sync(helpers.createOptions({
+            filterPackages: (pkg) => {
+              return [ 'bar', 'flat' ].indexOf(pkg.name) < 0
+            }
+          }))
 
           expect(caller).to.be.null
         })

--- a/test/knockknock.flat.spec.js
+++ b/test/knockknock.flat.spec.js
@@ -37,6 +37,7 @@ describe('knockknock:fixture:flat', () => {
         return flat.foo(helpers.createOptions())
           .then((caller) => {
             expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
               file: 'flat/src/flat.js',
               line: 36,
               name: 'flatFooFunction',
@@ -65,6 +66,7 @@ describe('knockknock:fixture:flat', () => {
         return flat.bar(helpers.createOptions())
           .then((caller) => {
             expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
               file: 'flat/node_modules/bar/src/bar.js',
               line: 28,
               name: 'barFunction',
@@ -83,6 +85,7 @@ describe('knockknock:fixture:flat', () => {
           return flat.bar(helpers.createOptions({ excludes: 'bar' }))
             .then((caller) => {
               expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
                 file: 'flat/src/flat.js',
                 line: 29,
                 name: 'flatBarFunction',
@@ -102,6 +105,7 @@ describe('knockknock:fixture:flat', () => {
           return flat.bar(helpers.createOptions({ excludes: 'flat' }))
             .then((caller) => {
               expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
                 file: 'flat/node_modules/bar/src/bar.js',
                 line: 28,
                 name: 'barFunction',
@@ -135,6 +139,7 @@ describe('knockknock:fixture:flat', () => {
         const caller = flat.foo.sync(helpers.createOptions())
 
         expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
           file: 'flat/src/flat.js',
           line: 39,
           name: 'flatFooSyncFunction',
@@ -161,6 +166,7 @@ describe('knockknock:fixture:flat', () => {
         const caller = flat.bar.sync(helpers.createOptions())
 
         expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
           file: 'flat/node_modules/bar/src/bar.js',
           line: 31,
           name: 'barSyncFunction',
@@ -178,6 +184,7 @@ describe('knockknock:fixture:flat', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: 'bar' }))
 
           expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
             file: 'flat/src/flat.js',
             line: 32,
             name: 'flatBarSyncFunction',
@@ -196,6 +203,7 @@ describe('knockknock:fixture:flat', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: 'flat' }))
 
           expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
             file: 'flat/node_modules/bar/src/bar.js',
             line: 31,
             name: 'barSyncFunction',

--- a/test/knockknock.flat.spec.js
+++ b/test/knockknock.flat.spec.js
@@ -23,6 +23,7 @@
 'use strict'
 
 const expect = require('chai').expect
+const path = require('path')
 
 const flat = require('./fixtures/flat/src/flat')
 const helpers = require('./helpers')
@@ -49,6 +50,24 @@ describe('knockknock:fixture:flat', () => {
               }
             }))
           })
+      })
+
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return promise for null', () => {
+          return flat.foo(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'flat.js' }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return promise for null', () => {
+          return flat.foo(helpers.createOptions({ filterFiles: () => false }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
       })
 
       context('and file package is excluded via "excludes"', () => {
@@ -87,6 +106,35 @@ describe('knockknock:fixture:flat', () => {
               }
             }))
           })
+      })
+
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return promise for caller & package information for fixture file', () => {
+          return flat.bar(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'bar.js' }))
+            .then((caller) => {
+              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'flat/src/flat.js',
+                line: 29,
+                name: 'flatBarFunction',
+                package: {
+                  directory: 'flat',
+                  main: 'flat/src/flat.js',
+                  name: 'flat',
+                  version: '1.0.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return promise for null', () => {
+          return flat.bar(helpers.createOptions({ filterFiles: () => false }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
       })
 
       context('and "knocking" package is excluded via "excludes"', () => {
@@ -169,7 +217,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "excludes"', () => {
+      context('and both file package and "knocking" package are excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return flat.bar(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
             .then((caller) => {
@@ -178,7 +226,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
         it('should return promise for null', () => {
           return flat.bar(helpers.createOptions({ filterPackages: (pkg) => [ 'bar', 'flat' ].indexOf(pkg.name) < 0 }))
             .then((caller) => {
@@ -210,7 +258,27 @@ describe('knockknock:fixture:flat', () => {
         }))
       })
 
-      context('and package is excluded via "excludes"', () => {
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return null', () => {
+          const caller = flat.foo.sync(helpers.createOptions({
+            filterFiles: (filePath) => {
+              return path.basename(filePath) !== 'flat.js'
+            }
+          }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return null', () => {
+          const caller = flat.foo.sync(helpers.createOptions({ filterFiles: () => false }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and file package is excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = flat.foo.sync(helpers.createOptions({ excludes: 'flat' }))
 
@@ -218,7 +286,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and package is excluded via "filterPackages"', () => {
+      context('and file package is excluded via "filterPackages"', () => {
         it('should return null', () => {
           const caller = flat.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
 
@@ -243,6 +311,37 @@ describe('knockknock:fixture:flat', () => {
             version: '1.1.2'
           }
         }))
+      })
+
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return caller & package information for fixture file', () => {
+          const caller = flat.bar.sync(helpers.createOptions({
+            filterFiles: (filePath) => {
+              return path.basename(filePath) !== 'bar.js'
+            }
+          }))
+
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'flat/src/flat.js',
+            line: 32,
+            name: 'flatBarSyncFunction',
+            package: {
+              directory: 'flat',
+              main: 'flat/src/flat.js',
+              name: 'flat',
+              version: '1.0.1'
+            }
+          }))
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return null', () => {
+          const caller = flat.bar.sync(helpers.createOptions({ filterFiles: () => false }))
+
+          expect(caller).to.be.null
+        })
       })
 
       context('and "knocking" package is excluded via "excludes"', () => {
@@ -283,7 +382,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and package is excluded via "excludes"', () => {
+      context('and file package is excluded via "excludes"', () => {
         it('should return caller & package information for indirect fixture file', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: 'flat' }))
 
@@ -302,7 +401,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and package is excluded via "filterPackages"', () => {
+      context('and file package is excluded via "filterPackages"', () => {
         it('should return caller & package information for indirect fixture file', () => {
           const caller = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
 
@@ -321,7 +420,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "excludes"', () => {
+      context('and both file package and "knocking" package are excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = flat.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
 
@@ -329,7 +428,7 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
         it('should return null', () => {
           const caller = flat.bar.sync(helpers.createOptions({
             filterPackages: (pkg) => {

--- a/test/knockknock.flat.spec.js
+++ b/test/knockknock.flat.spec.js
@@ -34,66 +34,89 @@ describe('knockknock:fixture:flat', () => {
     before(() => knockknock.clearCache())
 
     context('and module calls "knocking" module directly', () => {
-      it('should return promise for caller & package information for fixture file', () => {
+      it('should return promise for callers (incl. packages) before "knocking" file', () => {
         return flat.foo(helpers.createOptions())
-          .then((caller) => {
-            expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
-              column: 10,
-              file: 'flat/src/flat.js',
-              line: 36,
-              name: 'flatFooFunction',
-              package: {
-                directory: 'flat',
-                main: 'flat/src/flat.js',
-                name: 'flat',
-                version: '1.0.1'
-              }
-            }))
-          })
+        .then((callers) => {
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 10,
+            file: 'flat/src/flat.js',
+            line: 36,
+            name: 'flatFooFunction',
+            package: {
+              directory: 'flat',
+              main: 'flat/src/flat.js',
+              name: 'flat',
+              version: '1.0.1'
+            }
+          }))
+        })
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return promise for null', () => {
+      context('and limited to a single caller via "limit"', () => {
+        it('should return promise for only caller (incl. package) before "knocking" file', () => {
+          return flat.foo(helpers.createOptions({ limit: 1 }))
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'flat/src/flat.js',
+                line: 36,
+                name: 'flatFooFunction',
+                package: {
+                  directory: 'flat',
+                  main: 'flat/src/flat.js',
+                  name: 'flat',
+                  version: '1.0.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return promise for empty array', () => {
           return flat.foo(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'flat.js' }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return promise for null', () => {
+        it('should return promise for empty array', () => {
           return flat.foo(helpers.createOptions({ filterFiles: () => false }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return promise for null', () => {
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return promise for empty array', () => {
           return flat.foo(helpers.createOptions({ excludes: 'flat' }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return promise for null', () => {
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return promise for empty array', () => {
           return flat.foo(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
     })
 
     context('and module calls "knocking" module indirectly', () => {
-      it('should return promise for caller & package information for indirect fixture file', () => {
+      it('should return promise for callers (incl. packages) before "knocking" file', () => {
         return flat.bar(helpers.createOptions())
-          .then((caller) => {
-            expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(2)
+            expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
               column: 10,
               file: 'flat/node_modules/bar/src/bar.js',
               line: 28,
@@ -105,14 +128,48 @@ describe('knockknock:fixture:flat', () => {
                 version: '1.1.2'
               }
             }))
+            expect(callers[1]).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
+              file: 'flat/src/flat.js',
+              line: 29,
+              name: 'flatBarFunction',
+              package: {
+                directory: 'flat',
+                main: 'flat/src/flat.js',
+                name: 'flat',
+                version: '1.0.1'
+              }
+            }))
           })
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return promise for caller & package information for fixture file', () => {
+      context('and limited to a single caller via "limit"', () => {
+        it('should return promise for only caller (incl. package) before "knocking" file', () => {
+          return flat.bar(helpers.createOptions({ limit: 1 }))
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'flat/node_modules/bar/src/bar.js',
+                line: 28,
+                name: 'barFunction',
+                package: {
+                  directory: 'flat/node_modules/bar',
+                  main: 'flat/node_modules/bar/src/bar.js',
+                  name: 'bar',
+                  version: '1.1.2'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return promise for callers (incl. packages) before file before "knocking" file', () => {
           return flat.bar(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'bar.js' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'flat/src/flat.js',
                 line: 29,
@@ -129,19 +186,20 @@ describe('knockknock:fixture:flat', () => {
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return promise for null', () => {
+        it('should return promise for empty array', () => {
           return flat.bar(helpers.createOptions({ filterFiles: () => false }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and "knocking" package is excluded via "excludes"', () => {
-        it('should return promise for caller & package information for fixture file', () => {
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return promise for callers (incl. packages) before file before "knocking" file', () => {
           return flat.bar(helpers.createOptions({ excludes: 'bar' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'flat/src/flat.js',
                 line: 29,
@@ -157,11 +215,12 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and "knocking" package is excluded via "filterPackages"', () => {
-        it('should return promise for caller & package information for fixture file', () => {
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return promise for callers (incl. packages) before file before "knocking" file', () => {
           return flat.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'flat/src/flat.js',
                 line: 29,
@@ -177,11 +236,12 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return promise for caller & package information for indirect fixture file', () => {
+      context('and package for 2 files before "knocking" file package is excluded via "excludes"', () => {
+        it('should return promise for callers (incl. packages) before "knocking" file', () => {
           return flat.bar(helpers.createOptions({ excludes: 'flat' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'flat/node_modules/bar/src/bar.js',
                 line: 28,
@@ -197,11 +257,12 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return promise for caller & package information for indirect fixture file', () => {
+      context('and package for 2 files before "knocking" file package is excluded via "filterPackages"', () => {
+        it('should return promise for callers (incl. packages) before "knocking" file', () => {
           return flat.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'flat/node_modules/bar/src/bar.js',
                 line: 28,
@@ -217,20 +278,20 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "excludes"', () => {
-        it('should return promise for null', () => {
+      context('and packages for files before "knocking" file are excluded via "excludes"', () => {
+        it('should return promise for empty array', () => {
           return flat.bar(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
-        it('should return promise for null', () => {
+      context('and packages for files before "knocking" file are excluded via "filterPackages"', () => {
+        it('should return promise for empty array', () => {
           return flat.bar(helpers.createOptions({ filterPackages: (pkg) => [ 'bar', 'flat' ].indexOf(pkg.name) < 0 }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
@@ -241,10 +302,11 @@ describe('knockknock:fixture:flat', () => {
     before(() => knockknock.clearCache())
 
     context('and module calls "knocking" module directly', () => {
-      it('should return caller & package information for fixture file', () => {
-        const caller = flat.foo.sync(helpers.createOptions())
+      it('should return callers (incl. packages) before "knocking" file', () => {
+        const callers = flat.foo.sync(helpers.createOptions())
 
-        expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        expect(callers).to.have.lengthOf(1)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
           column: 14,
           file: 'flat/src/flat.js',
           line: 39,
@@ -258,48 +320,69 @@ describe('knockknock:fixture:flat', () => {
         }))
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return null', () => {
-          const caller = flat.foo.sync(helpers.createOptions({
+      context('and limited to a single caller via "limit"', () => {
+        it('should return only caller (incl. package) before "knocking" file', () => {
+          const callers = flat.foo.sync(helpers.createOptions({ limit: 1 }))
+
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'flat/src/flat.js',
+            line: 39,
+            name: 'flatFooSyncFunction',
+            package: {
+              directory: 'flat',
+              main: 'flat/src/flat.js',
+              name: 'flat',
+              version: '1.0.1'
+            }
+          }))
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return empty array', () => {
+          const callers = flat.foo.sync(helpers.createOptions({
             filterFiles: (filePath) => {
               return path.basename(filePath) !== 'flat.js'
             }
           }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return null', () => {
-          const caller = flat.foo.sync(helpers.createOptions({ filterFiles: () => false }))
+        it('should return empty array', () => {
+          const callers = flat.foo.sync(helpers.createOptions({ filterFiles: () => false }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return null', () => {
-          const caller = flat.foo.sync(helpers.createOptions({ excludes: 'flat' }))
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return empty array', () => {
+          const callers = flat.foo.sync(helpers.createOptions({ excludes: 'flat' }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return null', () => {
-          const caller = flat.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return empty array', () => {
+          const callers = flat.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
     })
 
     context('and module calls "knocking" module indirectly', () => {
-      it('should return caller & package information for indirect fixture file', () => {
-        const caller = flat.bar.sync(helpers.createOptions())
+      it('should return callers (incl. packages) before "knocking" file', () => {
+        const callers = flat.bar.sync(helpers.createOptions())
 
-        expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        expect(callers).to.have.lengthOf(2)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
           column: 14,
           file: 'flat/node_modules/bar/src/bar.js',
           line: 31,
@@ -311,17 +394,50 @@ describe('knockknock:fixture:flat', () => {
             version: '1.1.2'
           }
         }))
+        expect(callers[1]).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
+          file: 'flat/src/flat.js',
+          line: 32,
+          name: 'flatBarSyncFunction',
+          package: {
+            directory: 'flat',
+            main: 'flat/src/flat.js',
+            name: 'flat',
+            version: '1.0.1'
+          }
+        }))
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return caller & package information for fixture file', () => {
-          const caller = flat.bar.sync(helpers.createOptions({
+      context('and limited to a single caller via "limit"', () => {
+        it('should return only caller (incl. package) before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ limit: 1 }))
+
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'flat/node_modules/bar/src/bar.js',
+            line: 31,
+            name: 'barSyncFunction',
+            package: {
+              directory: 'flat/node_modules/bar',
+              main: 'flat/node_modules/bar/src/bar.js',
+              name: 'bar',
+              version: '1.1.2'
+            }
+          }))
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return callers (incl. packages) before file before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({
             filterFiles: (filePath) => {
               return path.basename(filePath) !== 'bar.js'
             }
           }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'flat/src/flat.js',
             line: 32,
@@ -337,18 +453,19 @@ describe('knockknock:fixture:flat', () => {
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return null', () => {
-          const caller = flat.bar.sync(helpers.createOptions({ filterFiles: () => false }))
+        it('should return empty array', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ filterFiles: () => false }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and "knocking" package is excluded via "excludes"', () => {
-        it('should return caller & package information for fixture file', () => {
-          const caller = flat.bar.sync(helpers.createOptions({ excludes: 'bar' }))
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return callers (incl. packages) before file before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ excludes: 'bar' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'flat/src/flat.js',
             line: 32,
@@ -363,11 +480,12 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and "knocking" package is excluded via "filterPackages"', () => {
-        it('should return caller & package information for fixture file', () => {
-          const caller = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return callers (incl. packages) before file before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'flat/src/flat.js',
             line: 32,
@@ -382,11 +500,12 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return caller & package information for indirect fixture file', () => {
-          const caller = flat.bar.sync(helpers.createOptions({ excludes: 'flat' }))
+      context('and package for 2 files before "knocking" file package is excluded via "excludes"', () => {
+        it('should return callers (incl. packages) before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ excludes: 'flat' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'flat/node_modules/bar/src/bar.js',
             line: 31,
@@ -401,11 +520,12 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return caller & package information for indirect fixture file', () => {
-          const caller = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
+      context('and package for 2 files before "knocking" file package is excluded via "filterPackages"', () => {
+        it('should return callers (incl. packages) before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'flat' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'flat/node_modules/bar/src/bar.js',
             line: 31,
@@ -420,23 +540,23 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "excludes"', () => {
-        it('should return null', () => {
-          const caller = flat.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
+      context('and packages for files before "knocking" file are excluded via "excludes"', () => {
+        it('should return empty array', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'flat' ] }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
-        it('should return null', () => {
-          const caller = flat.bar.sync(helpers.createOptions({
+      context('and packages for files before "knocking" file are excluded via "filterPackages"', () => {
+        it('should return empty array', () => {
+          const callers = flat.bar.sync(helpers.createOptions({
             filterPackages: (pkg) => {
               return [ 'bar', 'flat' ].indexOf(pkg.name) < 0
             }
           }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
     })

--- a/test/knockknock.flat.spec.js
+++ b/test/knockknock.flat.spec.js
@@ -53,6 +53,15 @@ describe('knockknock:fixture:flat', () => {
         })
       })
 
+      context('and first call is skipped via "offset"', () => {
+        it('should return promise for empty array', () => {
+          return flat.foo(helpers.createOptions({ offset: 1 }))
+            .then((callers) => {
+              expect(callers).to.be.empty
+            })
+        })
+      })
+
       context('and limited to a single caller via "limit"', () => {
         it('should return promise for only caller (incl. package) before "knocking" file', () => {
           return flat.foo(helpers.createOptions({ limit: 1 }))
@@ -141,6 +150,27 @@ describe('knockknock:fixture:flat', () => {
               }
             }))
           })
+      })
+
+      context('and first call is skipped via "offset"', () => {
+        it('should return promise for callers (incl. package) before file before "knocking" file', () => {
+          return flat.bar(helpers.createOptions({ offset: 1 }))
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'flat/src/flat.js',
+                line: 29,
+                name: 'flatBarFunction',
+                package: {
+                  directory: 'flat',
+                  main: 'flat/src/flat.js',
+                  name: 'flat',
+                  version: '1.0.1'
+                }
+              }))
+            })
+        })
       })
 
       context('and limited to a single caller via "limit"', () => {
@@ -320,6 +350,14 @@ describe('knockknock:fixture:flat', () => {
         }))
       })
 
+      context('and first call is skipped via "offset"', () => {
+        it('should return empty array', () => {
+          const callers = flat.foo.sync(helpers.createOptions({ offset: 1 }))
+
+          expect(callers).to.be.empty
+        })
+      })
+
       context('and limited to a single caller via "limit"', () => {
         it('should return only caller (incl. package) before "knocking" file', () => {
           const callers = flat.foo.sync(helpers.createOptions({ limit: 1 }))
@@ -406,6 +444,26 @@ describe('knockknock:fixture:flat', () => {
             version: '1.0.1'
           }
         }))
+      })
+
+      context('and first call is skipped via "offset"', () => {
+        it('should return callers (incl. package) before file before "knocking" file', () => {
+          const callers = flat.bar.sync(helpers.createOptions({ offset: 1 }))
+
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'flat/src/flat.js',
+            line: 32,
+            name: 'flatBarSyncFunction',
+            package: {
+              directory: 'flat',
+              main: 'flat/src/flat.js',
+              name: 'flat',
+              version: '1.0.1'
+            }
+          }))
+        })
       })
 
       context('and limited to a single caller via "limit"', () => {

--- a/test/knockknock.internal.spec.js
+++ b/test/knockknock.internal.spec.js
@@ -50,9 +50,18 @@ describe('knockknock:fixture:internal', () => {
         })
     })
 
-    context('and package is excluded', () => {
+    context('and package is excluded via "excludes"', () => {
       it('should return promise for null', () => {
         return internal(helpers.createOptions({ excludes: 'internal' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return promise for null', () => {
+        return internal(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'internal' }))
           .then((caller) => {
             expect(caller).to.be.null
           })
@@ -80,9 +89,17 @@ describe('knockknock:fixture:internal', () => {
       }))
     })
 
-    context('and package is excluded', () => {
+    context('and package is excluded via "excludes"', () => {
       it('should return null', () => {
         const caller = internal.sync(helpers.createOptions({ excludes: 'internal' }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return null', () => {
+        const caller = internal.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'internal' }))
 
         expect(caller).to.be.null
       })

--- a/test/knockknock.internal.spec.js
+++ b/test/knockknock.internal.spec.js
@@ -64,6 +64,27 @@ describe('knockknock:fixture:internal', () => {
         })
     })
 
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for callers (incl. package) before file before "knocking" file', () => {
+        return internal(helpers.createOptions({ offset: 1 }))
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(1)
+            expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 30,
+              file: 'internal/src/internal.js',
+              line: 30,
+              name: 'internalFunction',
+              package: {
+                directory: 'internal',
+                main: 'internal/src/internal',
+                name: 'internal',
+                version: '2.0.1'
+              }
+            }))
+          })
+      })
+    })
+
     context('and limited to a single caller via "limit"', () => {
       it('should return promise for only caller (incl. package) before "knocking" file', () => {
         return internal(helpers.createOptions({ limit: 1 }))
@@ -153,6 +174,26 @@ describe('knockknock:fixture:internal', () => {
           version: '2.0.1'
         }
       }))
+    })
+
+    context('and first call is skipped via "offset"', () => {
+      it('should return callers (incl. package) before file before "knocking" file', () => {
+        const callers = internal.sync(helpers.createOptions({ offset: 1 }))
+
+        expect(callers).to.have.lengthOf(1)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 4,
+          file: 'internal/src/internal.js',
+          line: 35,
+          name: 'internalSyncFunction',
+          package: {
+            directory: 'internal',
+            main: 'internal/src/internal',
+            name: 'internal',
+            version: '2.0.1'
+          }
+        }))
+      })
     })
 
     context('and limited to a single caller via "limit"', () => {

--- a/test/knockknock.internal.spec.js
+++ b/test/knockknock.internal.spec.js
@@ -23,6 +23,7 @@
 'use strict'
 
 const expect = require('chai').expect
+const path = require('path')
 
 const helpers = require('./helpers')
 const internal = require('./fixtures/internal/src/internal')
@@ -48,6 +49,24 @@ describe('knockknock:fixture:internal', () => {
             }
           }))
         })
+    })
+
+    context('and file is excluded via "filterFiles"', () => {
+      it('should return promise for null', () => {
+        return internal(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'internal.js' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return promise for null', () => {
+        return internal(helpers.createOptions({ filterFiles: () => false }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
     })
 
     context('and package is excluded via "excludes"', () => {
@@ -87,6 +106,26 @@ describe('knockknock:fixture:internal', () => {
           version: '2.0.1'
         }
       }))
+    })
+
+    context('and file is excluded via "filterFiles"', () => {
+      it('should return null', () => {
+        const caller = internal.sync(helpers.createOptions({
+          filterFiles: (filePath) => {
+            return path.basename(filePath) !== 'internal.js'
+          }
+        }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return null', () => {
+        const caller = internal.sync(helpers.createOptions({ filterFiles: () => false }))
+
+        expect(caller).to.be.null
+      })
     })
 
     context('and package is excluded via "excludes"', () => {

--- a/test/knockknock.internal.spec.js
+++ b/test/knockknock.internal.spec.js
@@ -36,6 +36,7 @@ describe('knockknock:fixture:internal', () => {
       return internal(helpers.createOptions())
         .then((caller) => {
           expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 17,
             file: 'internal/src/internal.js',
             line: 30,
             name: '<anonymous>',
@@ -66,6 +67,7 @@ describe('knockknock:fixture:internal', () => {
       const caller = internal.sync(helpers.createOptions())
 
       expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        column: 16,
         file: 'internal/src/internal.js',
         line: 34,
         name: '<anonymous>',

--- a/test/knockknock.nested.spec.js
+++ b/test/knockknock.nested.spec.js
@@ -37,6 +37,7 @@ describe('knockknock:fixture:nested', () => {
         return nested.foo(helpers.createOptions())
           .then((caller) => {
             expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
               file: 'nested/src/nested.js',
               line: 36,
               name: 'nestedFooFunction',
@@ -65,6 +66,7 @@ describe('knockknock:fixture:nested', () => {
         return nested.bar(helpers.createOptions())
           .then((caller) => {
             expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
               file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
               line: 28,
               name: 'barFunction',
@@ -83,6 +85,7 @@ describe('knockknock:fixture:nested', () => {
           return nested.bar(helpers.createOptions({ excludes: 'bar' }))
             .then((caller) => {
               expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
                 file: 'nested/src/nested.js',
                 line: 29,
                 name: 'nestedBarFunction',
@@ -102,6 +105,7 @@ describe('knockknock:fixture:nested', () => {
           return nested.bar(helpers.createOptions({ excludes: 'nested' }))
             .then((caller) => {
               expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
                 file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
                 line: 28,
                 name: 'barFunction',
@@ -135,6 +139,7 @@ describe('knockknock:fixture:nested', () => {
         const caller = nested.foo.sync(helpers.createOptions())
 
         expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
           file: 'nested/src/nested.js',
           line: 39,
           name: 'nestedFooSyncFunction',
@@ -161,6 +166,7 @@ describe('knockknock:fixture:nested', () => {
         const caller = nested.bar.sync(helpers.createOptions())
 
         expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
           file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
           line: 31,
           name: 'barSyncFunction',
@@ -178,6 +184,7 @@ describe('knockknock:fixture:nested', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: 'bar' }))
 
           expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
             file: 'nested/src/nested.js',
             line: 32,
             name: 'nestedBarSyncFunction',
@@ -196,6 +203,7 @@ describe('knockknock:fixture:nested', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: 'nested' }))
 
           expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
             file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
             line: 31,
             name: 'barSyncFunction',

--- a/test/knockknock.nested.spec.js
+++ b/test/knockknock.nested.spec.js
@@ -51,9 +51,18 @@ describe('knockknock:fixture:nested', () => {
           })
       })
 
-      context('and package is excluded', () => {
+      context('and package is excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return nested.foo(helpers.createOptions({ excludes: 'nested' }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and package is excluded via "filterPackages"', () => {
+        it('should return promise for null', () => {
+          return nested.foo(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
             .then((caller) => {
               expect(caller).to.be.null
             })
@@ -80,7 +89,7 @@ describe('knockknock:fixture:nested', () => {
           })
       })
 
-      context('and "knocking" package is excluded', () => {
+      context('and "knocking" package is excluded via "excludes"', () => {
         it('should return promise for caller & package information for fixture file', () => {
           return nested.bar(helpers.createOptions({ excludes: 'bar' }))
             .then((caller) => {
@@ -100,7 +109,27 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded', () => {
+      context('and "knocking" package is excluded via "filterPackages"', () => {
+        it('should return promise for caller & package information for fixture file', () => {
+          return nested.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
+            .then((caller) => {
+              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'nested/src/nested.js',
+                line: 29,
+                name: 'nestedBarFunction',
+                package: {
+                  directory: 'nested',
+                  main: 'nested/src/nested.js',
+                  name: 'nested',
+                  version: '3.0.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and package is excluded via "excludes"', () => {
         it('should return promise for caller & package information for indirect fixture file', () => {
           return nested.bar(helpers.createOptions({ excludes: 'nested' }))
             .then((caller) => {
@@ -120,9 +149,42 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded', () => {
+      context('and package is excluded via "filterPackages"', () => {
+        it('should return promise for caller & package information for indirect fixture file', () => {
+          return nested.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
+            .then((caller) => {
+              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+                line: 28,
+                name: 'barFunction',
+                package: {
+                  directory: 'nested/node_modules/foo/node_modules/bar',
+                  main: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+                  name: 'bar',
+                  version: '3.2.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return nested.bar(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+        it('should return promise for null', () => {
+          return nested.bar(helpers.createOptions({
+            filterPackages: (pkg) => {
+              return [ 'bar', 'nested' ].indexOf(pkg.name) < 0
+            }
+          }))
             .then((caller) => {
               expect(caller).to.be.null
             })
@@ -152,9 +214,17 @@ describe('knockknock:fixture:nested', () => {
         }))
       })
 
-      context('and package is excluded', () => {
+      context('and package is excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = nested.foo.sync(helpers.createOptions({ excludes: 'nested' }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and package is excluded via "filterPackages"', () => {
+        it('should return null', () => {
+          const caller = nested.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
 
           expect(caller).to.be.null
         })
@@ -179,7 +249,7 @@ describe('knockknock:fixture:nested', () => {
         }))
       })
 
-      context('and "knocking" package is excluded', () => {
+      context('and "knocking" package is excluded via "excludes"', () => {
         it('should return caller & package information for fixture file', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: 'bar' }))
 
@@ -198,7 +268,26 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded', () => {
+      context('and "knocking" package is excluded via "filterPackages"', () => {
+        it('should return caller & package information for fixture file', () => {
+          const caller = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
+
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'nested/src/nested.js',
+            line: 32,
+            name: 'nestedBarSyncFunction',
+            package: {
+              directory: 'nested',
+              main: 'nested/src/nested.js',
+              name: 'nested',
+              version: '3.0.1'
+            }
+          }))
+        })
+      })
+
+      context('and package is excluded via "excludes"', () => {
         it('should return caller & package information for indirect fixture file', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: 'nested' }))
 
@@ -217,9 +306,40 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded', () => {
+      context('and package is excluded via "filterPackages"', () => {
+        it('should return caller & package information for indirect fixture file', () => {
+          const caller = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
+
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+            line: 31,
+            name: 'barSyncFunction',
+            package: {
+              directory: 'nested/node_modules/foo/node_modules/bar',
+              main: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+              name: 'bar',
+              version: '3.2.1'
+            }
+          }))
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+        it('should return null', () => {
+          const caller = nested.bar.sync(helpers.createOptions({
+            filterPackages: (pkg) => {
+              return [ 'bar', 'nested' ].indexOf(pkg.name) < 0
+            }
+          }))
 
           expect(caller).to.be.null
         })

--- a/test/knockknock.nested.spec.js
+++ b/test/knockknock.nested.spec.js
@@ -53,6 +53,15 @@ describe('knockknock:fixture:nested', () => {
           })
       })
 
+      context('and first call is skipped via "offset"', () => {
+        it('should return promise for empty array', () => {
+          return nested.foo(helpers.createOptions({ offset: 1 }))
+            .then((callers) => {
+              expect(callers).to.be.empty
+            })
+        })
+      })
+
       context('and limited to a single caller via "limit"', () => {
         it('should return promise for only caller (incl. package) before "knocking" file', () => {
           return nested.foo(helpers.createOptions({ limit: 1 }))
@@ -145,6 +154,27 @@ describe('knockknock:fixture:nested', () => {
               }
             }))
           })
+      })
+
+      context('and first call is skipped via "offset"', () => {
+        it('should return promise for callers (incl. package) before file before "knocking" file', () => {
+          return nested.bar(helpers.createOptions({ offset: 1 }))
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'nested/src/nested.js',
+                line: 29,
+                name: 'nestedBarFunction',
+                package: {
+                  directory: 'nested',
+                  main: 'nested/src/nested.js',
+                  name: 'nested',
+                  version: '3.0.1'
+                }
+              }))
+            })
+        })
       })
 
       context('and limited to a single caller via "limit"', () => {
@@ -328,6 +358,14 @@ describe('knockknock:fixture:nested', () => {
         }))
       })
 
+      context('and first call is skipped via "offset"', () => {
+        it('should return empty array', () => {
+          const callers = nested.foo.sync(helpers.createOptions({ offset: 1 }))
+
+          expect(callers).to.be.empty
+        })
+      })
+
       context('and limited to a single caller via "limit"', () => {
         it('should return only caller (incl. package) before "knocking" file', () => {
           const callers = nested.foo.sync(helpers.createOptions({ limit: 1 }))
@@ -414,6 +452,26 @@ describe('knockknock:fixture:nested', () => {
             version: '3.0.1'
           }
         }))
+      })
+
+      context('and first call is skipped via "offset"', () => {
+        it('should return callers (incl. package) before file before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ offset: 1 }))
+
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'nested/src/nested.js',
+            line: 32,
+            name: 'nestedBarSyncFunction',
+            package: {
+              directory: 'nested',
+              main: 'nested/src/nested.js',
+              name: 'nested',
+              version: '3.0.1'
+            }
+          }))
+        })
       })
 
       context('and limited to a single caller via "limit"', () => {

--- a/test/knockknock.nested.spec.js
+++ b/test/knockknock.nested.spec.js
@@ -34,10 +34,11 @@ describe('knockknock:fixture:nested', () => {
     before(() => knockknock.clearCache())
 
     context('and module calls "knocking" module directly', () => {
-      it('should return promise for caller & package information for fixture file', () => {
+      it('should return promise for callers (incl. packages) before "knocking" file', () => {
         return nested.foo(helpers.createOptions())
-          .then((caller) => {
-            expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(1)
+            expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
               column: 10,
               file: 'nested/src/nested.js',
               line: 36,
@@ -52,52 +53,74 @@ describe('knockknock:fixture:nested', () => {
           })
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return promise for null', () => {
+      context('and limited to a single caller via "limit"', () => {
+        it('should return promise for only caller (incl. package) before "knocking" file', () => {
+          return nested.foo(helpers.createOptions({ limit: 1 }))
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'nested/src/nested.js',
+                line: 36,
+                name: 'nestedFooFunction',
+                package: {
+                  directory: 'nested',
+                  main: 'nested/src/nested.js',
+                  name: 'nested',
+                  version: '3.0.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return promise for empty array', () => {
           return nested.foo(helpers.createOptions({
             filterFiles: (filePath) => {
               return path.basename(filePath) !== 'nested.js'
             }
           }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return promise for null', () => {
+        it('should return promise for empty array', () => {
           return nested.foo(helpers.createOptions({ filterFiles: () => false }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return promise for null', () => {
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return promise for empty array', () => {
           return nested.foo(helpers.createOptions({ excludes: 'nested' }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return promise for null', () => {
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return promise for empty array', () => {
           return nested.foo(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
     })
 
     context('and module calls "knocking" module indirectly', () => {
-      it('should return promise for caller & package information for indirect fixture file', () => {
+      it('should return promise for callers (incl. packages) before "knocking" file', () => {
         return nested.bar(helpers.createOptions())
-          .then((caller) => {
-            expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(2)
+            expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
               column: 10,
               file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
               line: 28,
@@ -109,14 +132,48 @@ describe('knockknock:fixture:nested', () => {
                 version: '3.2.1'
               }
             }))
+            expect(callers[1]).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
+              file: 'nested/src/nested.js',
+              line: 29,
+              name: 'nestedBarFunction',
+              package: {
+                directory: 'nested',
+                main: 'nested/src/nested.js',
+                name: 'nested',
+                version: '3.0.1'
+              }
+            }))
           })
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return promise for caller & package information for fixture file', () => {
+      context('and limited to a single caller via "limit"', () => {
+        it('should return promise for only caller (incl. package) before "knocking" file', () => {
+          return nested.bar(helpers.createOptions({ limit: 1 }))
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+                line: 28,
+                name: 'barFunction',
+                package: {
+                  directory: 'nested/node_modules/foo/node_modules/bar',
+                  main: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+                  name: 'bar',
+                  version: '3.2.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return promise for callers (incl. packages) before file before "knocking" file', () => {
           return nested.bar(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'bar.js' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'nested/src/nested.js',
                 line: 29,
@@ -133,19 +190,20 @@ describe('knockknock:fixture:nested', () => {
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return promise for null', () => {
+        it('should return promise for empty array', () => {
           return nested.bar(helpers.createOptions({ filterFiles: () => false }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and "knocking" package is excluded via "excludes"', () => {
-        it('should return promise for caller & package information for fixture file', () => {
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return promise for callers (incl. packages) before file before "knocking" file', () => {
           return nested.bar(helpers.createOptions({ excludes: 'bar' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'nested/src/nested.js',
                 line: 29,
@@ -161,11 +219,12 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and "knocking" package is excluded via "filterPackages"', () => {
-        it('should return promise for caller & package information for fixture file', () => {
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return promise for callers (incl. packages) before file before "knocking" file', () => {
           return nested.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'nested/src/nested.js',
                 line: 29,
@@ -181,11 +240,12 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return promise for caller & package information for indirect fixture file', () => {
+      context('and package for 2 files before "knocking" file package is excluded via "excludes"', () => {
+        it('should return promise for callers (incl. packages) before "knocking" file', () => {
           return nested.bar(helpers.createOptions({ excludes: 'nested' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
                 line: 28,
@@ -201,11 +261,12 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return promise for caller & package information for indirect fixture file', () => {
+      context('and package for 2 files before "knocking" file package is excluded via "filterPackages"', () => {
+        it('should return promise for callers (incl. packages) before "knocking" file', () => {
           return nested.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
-            .then((caller) => {
-              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            .then((callers) => {
+              expect(callers).to.have.lengthOf(1)
+              expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
                 column: 10,
                 file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
                 line: 28,
@@ -221,24 +282,24 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "excludes"', () => {
-        it('should return promise for null', () => {
+      context('and packages for files before "knocking" file are excluded via "excludes"', () => {
+        it('should return promise for empty array', () => {
           return nested.bar(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
-        it('should return promise for null', () => {
+      context('and packages for files before "knocking" file are excluded via "filterPackages"', () => {
+        it('should return promise for empty array', () => {
           return nested.bar(helpers.createOptions({
             filterPackages: (pkg) => {
               return [ 'bar', 'nested' ].indexOf(pkg.name) < 0
             }
           }))
-            .then((caller) => {
-              expect(caller).to.be.null
+            .then((callers) => {
+              expect(callers).to.be.empty
             })
         })
       })
@@ -249,10 +310,11 @@ describe('knockknock:fixture:nested', () => {
     before(() => knockknock.clearCache())
 
     context('and module calls "knocking" module directly', () => {
-      it('should return caller & package information for fixture file', () => {
-        const caller = nested.foo.sync(helpers.createOptions())
+      it('should return callers (incl. packages) before "knocking" file', () => {
+        const callers = nested.foo.sync(helpers.createOptions())
 
-        expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        expect(callers).to.have.lengthOf(1)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
           column: 14,
           file: 'nested/src/nested.js',
           line: 39,
@@ -266,48 +328,69 @@ describe('knockknock:fixture:nested', () => {
         }))
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return null', () => {
-          const caller = nested.foo.sync(helpers.createOptions({
+      context('and limited to a single caller via "limit"', () => {
+        it('should return only caller (incl. package) before "knocking" file', () => {
+          const callers = nested.foo.sync(helpers.createOptions({ limit: 1 }))
+
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'nested/src/nested.js',
+            line: 39,
+            name: 'nestedFooSyncFunction',
+            package: {
+              directory: 'nested',
+              main: 'nested/src/nested.js',
+              name: 'nested',
+              version: '3.0.1'
+            }
+          }))
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return empty array', () => {
+          const callers = nested.foo.sync(helpers.createOptions({
             filterFiles: (filePath) => {
               return path.basename(filePath) !== 'nested.js'
             }
           }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return null', () => {
-          const caller = nested.foo.sync(helpers.createOptions({ filterFiles: () => false }))
+        it('should return empty array', () => {
+          const callers = nested.foo.sync(helpers.createOptions({ filterFiles: () => false }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return null', () => {
-          const caller = nested.foo.sync(helpers.createOptions({ excludes: 'nested' }))
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return empty array', () => {
+          const callers = nested.foo.sync(helpers.createOptions({ excludes: 'nested' }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return null', () => {
-          const caller = nested.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return empty array', () => {
+          const callers = nested.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
     })
 
     context('and module calls "knocking" module indirectly', () => {
-      it('should return caller & package information for indirect fixture file', () => {
-        const caller = nested.bar.sync(helpers.createOptions())
+      it('should return callers (incl. packages) before "knocking" file', () => {
+        const callers = nested.bar.sync(helpers.createOptions())
 
-        expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        expect(callers).to.have.lengthOf(2)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
           column: 14,
           file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
           line: 31,
@@ -319,17 +402,50 @@ describe('knockknock:fixture:nested', () => {
             version: '3.2.1'
           }
         }))
+        expect(callers[1]).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
+          file: 'nested/src/nested.js',
+          line: 32,
+          name: 'nestedBarSyncFunction',
+          package: {
+            directory: 'nested',
+            main: 'nested/src/nested.js',
+            name: 'nested',
+            version: '3.0.1'
+          }
+        }))
       })
 
-      context('and file is excluded via "filterFiles"', () => {
-        it('should return caller & package information for fixture file', () => {
-          const caller = nested.bar.sync(helpers.createOptions({
+      context('and limited to a single caller via "limit"', () => {
+        it('should return only caller (incl. package) before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ limit: 1 }))
+
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+            line: 31,
+            name: 'barSyncFunction',
+            package: {
+              directory: 'nested/node_modules/foo/node_modules/bar',
+              main: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
+              name: 'bar',
+              version: '3.2.1'
+            }
+          }))
+        })
+      })
+
+      context('and file before "knocking" file is excluded via "filterFiles"', () => {
+        it('should return callers (incl. packages) before file before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({
             filterFiles: (filePath) => {
               return path.basename(filePath) !== 'bar.js'
             }
           }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'nested/src/nested.js',
             line: 32,
@@ -345,18 +461,19 @@ describe('knockknock:fixture:nested', () => {
       })
 
       context('and all files are excluded via "filterFiles"', () => {
-        it('should return null', () => {
-          const caller = nested.bar.sync(helpers.createOptions({ filterFiles: () => false }))
+        it('should return empty array', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ filterFiles: () => false }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and "knocking" package is excluded via "excludes"', () => {
-        it('should return caller & package information for fixture file', () => {
-          const caller = nested.bar.sync(helpers.createOptions({ excludes: 'bar' }))
+      context('and package for file before "knocking" file is excluded via "excludes"', () => {
+        it('should return callers (incl. packages) before file before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ excludes: 'bar' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'nested/src/nested.js',
             line: 32,
@@ -371,11 +488,12 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and "knocking" package is excluded via "filterPackages"', () => {
-        it('should return caller & package information for fixture file', () => {
-          const caller = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
+      context('and package for file before "knocking" file is excluded via "filterPackages"', () => {
+        it('should return callers (incl. packages) before file before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'bar' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'nested/src/nested.js',
             line: 32,
@@ -390,11 +508,12 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and file package is excluded via "excludes"', () => {
-        it('should return caller & package information for indirect fixture file', () => {
-          const caller = nested.bar.sync(helpers.createOptions({ excludes: 'nested' }))
+      context('and package for 2 files before "knocking" file package is excluded via "excludes"', () => {
+        it('should return callers (incl. packages) before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ excludes: 'nested' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
             line: 31,
@@ -409,11 +528,12 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and file package is excluded via "filterPackages"', () => {
-        it('should return caller & package information for indirect fixture file', () => {
-          const caller = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
+      context('and package for 2 files before "knocking" file package is excluded via "filterPackages"', () => {
+        it('should return callers (incl. packages) before "knocking" file', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
 
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 14,
             file: 'nested/node_modules/foo/node_modules/bar/src/bar.js',
             line: 31,
@@ -428,23 +548,23 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "excludes"', () => {
-        it('should return null', () => {
-          const caller = nested.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
+      context('and packages for files before "knocking" file are excluded via "excludes"', () => {
+        it('should return empty array', () => {
+          const callers = nested.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
 
-      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
-        it('should return null', () => {
-          const caller = nested.bar.sync(helpers.createOptions({
+      context('and packages for files before "knocking" file are excluded via "filterPackages"', () => {
+        it('should return empty array', () => {
+          const callers = nested.bar.sync(helpers.createOptions({
             filterPackages: (pkg) => {
               return [ 'bar', 'nested' ].indexOf(pkg.name) < 0
             }
           }))
 
-          expect(caller).to.be.null
+          expect(callers).to.be.empty
         })
       })
     })

--- a/test/knockknock.nested.spec.js
+++ b/test/knockknock.nested.spec.js
@@ -23,6 +23,7 @@
 'use strict'
 
 const expect = require('chai').expect
+const path = require('path')
 
 const helpers = require('./helpers')
 const knockknock = require('../src/knockknock')
@@ -51,7 +52,29 @@ describe('knockknock:fixture:nested', () => {
           })
       })
 
-      context('and package is excluded via "excludes"', () => {
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return promise for null', () => {
+          return nested.foo(helpers.createOptions({
+            filterFiles: (filePath) => {
+              return path.basename(filePath) !== 'nested.js'
+            }
+          }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return promise for null', () => {
+          return nested.foo(helpers.createOptions({ filterFiles: () => false }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
+      })
+
+      context('and file package is excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return nested.foo(helpers.createOptions({ excludes: 'nested' }))
             .then((caller) => {
@@ -60,7 +83,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded via "filterPackages"', () => {
+      context('and file package is excluded via "filterPackages"', () => {
         it('should return promise for null', () => {
           return nested.foo(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
             .then((caller) => {
@@ -87,6 +110,35 @@ describe('knockknock:fixture:nested', () => {
               }
             }))
           })
+      })
+
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return promise for caller & package information for fixture file', () => {
+          return nested.bar(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'bar.js' }))
+            .then((caller) => {
+              expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+                column: 10,
+                file: 'nested/src/nested.js',
+                line: 29,
+                name: 'nestedBarFunction',
+                package: {
+                  directory: 'nested',
+                  main: 'nested/src/nested.js',
+                  name: 'nested',
+                  version: '3.0.1'
+                }
+              }))
+            })
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return promise for null', () => {
+          return nested.bar(helpers.createOptions({ filterFiles: () => false }))
+            .then((caller) => {
+              expect(caller).to.be.null
+            })
+        })
       })
 
       context('and "knocking" package is excluded via "excludes"', () => {
@@ -129,7 +181,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded via "excludes"', () => {
+      context('and file package is excluded via "excludes"', () => {
         it('should return promise for caller & package information for indirect fixture file', () => {
           return nested.bar(helpers.createOptions({ excludes: 'nested' }))
             .then((caller) => {
@@ -149,7 +201,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded via "filterPackages"', () => {
+      context('and file package is excluded via "filterPackages"', () => {
         it('should return promise for caller & package information for indirect fixture file', () => {
           return nested.bar(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
             .then((caller) => {
@@ -169,7 +221,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "excludes"', () => {
+      context('and both file package and "knocking" package are excluded via "excludes"', () => {
         it('should return promise for null', () => {
           return nested.bar(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
             .then((caller) => {
@@ -178,7 +230,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
         it('should return promise for null', () => {
           return nested.bar(helpers.createOptions({
             filterPackages: (pkg) => {
@@ -214,7 +266,27 @@ describe('knockknock:fixture:nested', () => {
         }))
       })
 
-      context('and package is excluded via "excludes"', () => {
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return null', () => {
+          const caller = nested.foo.sync(helpers.createOptions({
+            filterFiles: (filePath) => {
+              return path.basename(filePath) !== 'nested.js'
+            }
+          }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return null', () => {
+          const caller = nested.foo.sync(helpers.createOptions({ filterFiles: () => false }))
+
+          expect(caller).to.be.null
+        })
+      })
+
+      context('and file package is excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = nested.foo.sync(helpers.createOptions({ excludes: 'nested' }))
 
@@ -222,7 +294,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded via "filterPackages"', () => {
+      context('and file package is excluded via "filterPackages"', () => {
         it('should return null', () => {
           const caller = nested.foo.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
 
@@ -247,6 +319,37 @@ describe('knockknock:fixture:nested', () => {
             version: '3.2.1'
           }
         }))
+      })
+
+      context('and file is excluded via "filterFiles"', () => {
+        it('should return caller & package information for fixture file', () => {
+          const caller = nested.bar.sync(helpers.createOptions({
+            filterFiles: (filePath) => {
+              return path.basename(filePath) !== 'bar.js'
+            }
+          }))
+
+          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 14,
+            file: 'nested/src/nested.js',
+            line: 32,
+            name: 'nestedBarSyncFunction',
+            package: {
+              directory: 'nested',
+              main: 'nested/src/nested.js',
+              name: 'nested',
+              version: '3.0.1'
+            }
+          }))
+        })
+      })
+
+      context('and all files are excluded via "filterFiles"', () => {
+        it('should return null', () => {
+          const caller = nested.bar.sync(helpers.createOptions({ filterFiles: () => false }))
+
+          expect(caller).to.be.null
+        })
       })
 
       context('and "knocking" package is excluded via "excludes"', () => {
@@ -287,7 +390,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded via "excludes"', () => {
+      context('and file package is excluded via "excludes"', () => {
         it('should return caller & package information for indirect fixture file', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: 'nested' }))
 
@@ -306,7 +409,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and package is excluded via "filterPackages"', () => {
+      context('and file package is excluded via "filterPackages"', () => {
         it('should return caller & package information for indirect fixture file', () => {
           const caller = nested.bar.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'nested' }))
 
@@ -325,7 +428,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "excludes"', () => {
+      context('and both file package and "knocking" package are excluded via "excludes"', () => {
         it('should return null', () => {
           const caller = nested.bar.sync(helpers.createOptions({ excludes: [ 'bar', 'nested' ] }))
 
@@ -333,7 +436,7 @@ describe('knockknock:fixture:nested', () => {
         })
       })
 
-      context('and both package and "knocking" package are excluded via "filterPackages"', () => {
+      context('and both file package and "knocking" package are excluded via "filterPackages"', () => {
         it('should return null', () => {
           const caller = nested.bar.sync(helpers.createOptions({
             filterPackages: (pkg) => {

--- a/test/knockknock.server.spec.js
+++ b/test/knockknock.server.spec.js
@@ -33,10 +33,11 @@ describe('knockknock:fixture:server', () => {
   context('when asynchronous', () => {
     before(() => knockknock.clearCache())
 
-    it('should return promise for caller & package information for fixture file', () => {
+    it('should return promise for callers (incl. packages) before "knocking" file', () => {
       return server(helpers.createOptions())
-        .then((caller) => {
-          expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        .then((callers) => {
+          expect(callers).to.have.lengthOf(1)
+          expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
             column: 10,
             file: 'server/server.js',
             line: 28,
@@ -51,38 +52,59 @@ describe('knockknock:fixture:server', () => {
         })
     })
 
-    context('and file is excluded via "filterFiles"', () => {
-      it('should return promise for null', () => {
+    context('and limited to a single caller via "limit"', () => {
+      it('should return promise for only caller (excl. package) before "knocking" file', () => {
+        return server(helpers.createOptions({ limit: 1 }))
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(1)
+            expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+              column: 10,
+              file: 'server/server.js',
+              line: 28,
+              name: 'serverFunction',
+              package: {
+                directory: 'server',
+                main: null,
+                name: 'server',
+                version: '4.0.1'
+              }
+            }))
+          })
+      })
+    })
+
+    context('and file before "knocking" file is excluded via "filterFiles"', () => {
+      it('should return promise for empty array', () => {
         return server(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'server.js' }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
 
     context('and all files are excluded via "filterFiles"', () => {
-      it('should return promise for null', () => {
+      it('should return promise for empty array', () => {
         return server(helpers.createOptions({ filterFiles: () => false }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
 
     context('and package is excluded via "excludes"', () => {
-      it('should return promise for null', () => {
+      it('should return promise for empty array', () => {
         return server(helpers.createOptions({ excludes: 'server' }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
 
     context('and package is excluded via "filterPackages"', () => {
-      it('should return promise for null', () => {
+      it('should return promise for empty array', () => {
         return server(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'server' }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
@@ -91,10 +113,11 @@ describe('knockknock:fixture:server', () => {
   context('when synchronous', () => {
     before(() => knockknock.clearCache())
 
-    it('should return caller & package information for fixture file', () => {
-      const caller = server.sync(helpers.createOptions())
+    it('should return callers (incl. packages) before "knocking" file', () => {
+      const callers = server.sync(helpers.createOptions())
 
-      expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+      expect(callers).to.have.lengthOf(1)
+      expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
         column: 14,
         file: 'server/server.js',
         line: 31,
@@ -108,39 +131,59 @@ describe('knockknock:fixture:server', () => {
       }))
     })
 
-    context('and file is excluded via "filterFiles"', () => {
-      it('should return null', () => {
-        const caller = server.sync(helpers.createOptions({
+    context('and limited to a single caller via "limit"', () => {
+      it('should return only caller (excl. package) before "knocking" file', () => {
+        const callers = server.sync(helpers.createOptions({ limit: 1 }))
+
+        expect(callers).to.have.lengthOf(1)
+        expect(callers[0]).to.deep.equal(helpers.resolveCallerForFixture({
+          column: 14,
+          file: 'server/server.js',
+          line: 31,
+          name: 'serverSyncFunction',
+          package: {
+            directory: 'server',
+            main: null,
+            name: 'server',
+            version: '4.0.1'
+          }
+        }))
+      })
+    })
+
+    context('and file before "knocking" file is excluded via "filterFiles"', () => {
+      it('should return empty array', () => {
+        const callers = server.sync(helpers.createOptions({
           filterFiles: (filePath) => {
             return path.basename(filePath) !== 'server.js'
           }
         }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
 
     context('and all files are excluded via "filterFiles"', () => {
-      it('should return null', () => {
-        const caller = server.sync(helpers.createOptions({ filterFiles: () => false }))
+      it('should return empty array', () => {
+        const callers = server.sync(helpers.createOptions({ filterFiles: () => false }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
 
     context('and package is excluded via "excludes"', () => {
-      it('should return null', () => {
-        const caller = server.sync(helpers.createOptions({ excludes: 'server' }))
+      it('should return empty array', () => {
+        const callers = server.sync(helpers.createOptions({ excludes: 'server' }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
 
     context('and package is excluded via "filterPackages"', () => {
-      it('should return null', () => {
-        const caller = server.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'server' }))
+      it('should return empty array', () => {
+        const callers = server.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'server' }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
   })

--- a/test/knockknock.server.spec.js
+++ b/test/knockknock.server.spec.js
@@ -23,6 +23,7 @@
 'use strict'
 
 const expect = require('chai').expect
+const path = require('path')
 
 const helpers = require('./helpers')
 const knockknock = require('../src/knockknock')
@@ -48,6 +49,24 @@ describe('knockknock:fixture:server', () => {
             }
           }))
         })
+    })
+
+    context('and file is excluded via "filterFiles"', () => {
+      it('should return promise for null', () => {
+        return server(helpers.createOptions({ filterFiles: (filePath) => path.basename(filePath) !== 'server.js' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return promise for null', () => {
+        return server(helpers.createOptions({ filterFiles: () => false }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
     })
 
     context('and package is excluded via "excludes"', () => {
@@ -87,6 +106,26 @@ describe('knockknock:fixture:server', () => {
           version: '4.0.1'
         }
       }))
+    })
+
+    context('and file is excluded via "filterFiles"', () => {
+      it('should return null', () => {
+        const caller = server.sync(helpers.createOptions({
+          filterFiles: (filePath) => {
+            return path.basename(filePath) !== 'server.js'
+          }
+        }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return null', () => {
+        const caller = server.sync(helpers.createOptions({ filterFiles: () => false }))
+
+        expect(caller).to.be.null
+      })
     })
 
     context('and package is excluded via "excludes"', () => {

--- a/test/knockknock.server.spec.js
+++ b/test/knockknock.server.spec.js
@@ -50,9 +50,18 @@ describe('knockknock:fixture:server', () => {
         })
     })
 
-    context('and package is excluded', () => {
+    context('and package is excluded via "excludes"', () => {
       it('should return promise for null', () => {
         return server(helpers.createOptions({ excludes: 'server' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return promise for null', () => {
+        return server(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'server' }))
           .then((caller) => {
             expect(caller).to.be.null
           })
@@ -80,9 +89,17 @@ describe('knockknock:fixture:server', () => {
       }))
     })
 
-    context('and package is excluded', () => {
+    context('and package is excluded via "excludes"', () => {
       it('should return null', () => {
         const caller = server.sync(helpers.createOptions({ excludes: 'server' }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return null', () => {
+        const caller = server.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'server' }))
 
         expect(caller).to.be.null
       })

--- a/test/knockknock.server.spec.js
+++ b/test/knockknock.server.spec.js
@@ -36,6 +36,7 @@ describe('knockknock:fixture:server', () => {
       return server(helpers.createOptions())
         .then((caller) => {
           expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+            column: 10,
             file: 'server/server.js',
             line: 28,
             name: 'serverFunction',
@@ -66,6 +67,7 @@ describe('knockknock:fixture:server', () => {
       const caller = server.sync(helpers.createOptions())
 
       expect(caller).to.deep.equal(helpers.resolveCallerForFixture({
+        column: 14,
         file: 'server/server.js',
         line: 31,
         name: 'serverSyncFunction',

--- a/test/knockknock.server.spec.js
+++ b/test/knockknock.server.spec.js
@@ -52,6 +52,15 @@ describe('knockknock:fixture:server', () => {
         })
     })
 
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for empty array', () => {
+        return server(helpers.createOptions({ offset: 1 }))
+          .then((callers) => {
+            expect(callers).to.be.empty
+          })
+      })
+    })
+
     context('and limited to a single caller via "limit"', () => {
       it('should return promise for only caller (excl. package) before "knocking" file', () => {
         return server(helpers.createOptions({ limit: 1 }))
@@ -129,6 +138,14 @@ describe('knockknock:fixture:server', () => {
           version: '4.0.1'
         }
       }))
+    })
+
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for empty array', () => {
+        const callers = server.sync(helpers.createOptions({ offset: 1 }))
+
+        expect(callers).to.be.empty
+      })
     })
 
     context('and limited to a single caller via "limit"', () => {

--- a/test/knockknock.single.spec.js
+++ b/test/knockknock.single.spec.js
@@ -38,6 +38,33 @@ describe('knockknock:fixture:single', () => {
           expect(caller).to.be.null
         })
     })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return promise for null', () => {
+        return single(helpers.createOptions({ filterFiles: () => false }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and package is excluded via "excludes"', () => {
+      it('should return promise for null', () => {
+        return single(helpers.createOptions({ excludes: 'single' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return promise for null', () => {
+        return single(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'single' }))
+          .then((caller) => {
+            expect(caller).to.be.null
+          })
+      })
+    })
   })
 
   context('when synchronous', () => {
@@ -47,6 +74,30 @@ describe('knockknock:fixture:single', () => {
       const caller = single.sync(helpers.createOptions())
 
       expect(caller).to.be.null
+    })
+
+    context('and all files are excluded via "filterFiles"', () => {
+      it('should return null', () => {
+        const caller = single.sync(helpers.createOptions({ filterFiles: () => false }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and package is excluded via "excludes"', () => {
+      it('should return null', () => {
+        const caller = single.sync(helpers.createOptions({ excludes: 'single' }))
+
+        expect(caller).to.be.null
+      })
+    })
+
+    context('and package is excluded via "filterPackages"', () => {
+      it('should return null', () => {
+        const caller = single.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'single' }))
+
+        expect(caller).to.be.null
+      })
     })
   })
 })

--- a/test/knockknock.single.spec.js
+++ b/test/knockknock.single.spec.js
@@ -32,36 +32,45 @@ describe('knockknock:fixture:single', () => {
   context('when asynchronous', () => {
     before(() => knockknock.clearCache())
 
-    it('should return promise for null', () => {
+    it('should return promise for empty array', () => {
       return single(helpers.createOptions())
-        .then((caller) => {
-          expect(caller).to.be.null
+        .then((callers) => {
+          expect(callers).to.be.empty
         })
     })
 
+    context('and limited to a single caller via "limit"', () => {
+      it('should return promise for empty array', () => {
+        return single(helpers.createOptions({ limit: 1 }))
+          .then((callers) => {
+            expect(callers).to.be.empty
+          })
+      })
+    })
+
     context('and all files are excluded via "filterFiles"', () => {
-      it('should return promise for null', () => {
+      it('should return promise for empty array', () => {
         return single(helpers.createOptions({ filterFiles: () => false }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
 
     context('and package is excluded via "excludes"', () => {
-      it('should return promise for null', () => {
+      it('should return promise for empty array', () => {
         return single(helpers.createOptions({ excludes: 'single' }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
 
     context('and package is excluded via "filterPackages"', () => {
-      it('should return promise for null', () => {
+      it('should return promise for empty array', () => {
         return single(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'single' }))
-          .then((caller) => {
-            expect(caller).to.be.null
+          .then((callers) => {
+            expect(callers).to.be.empty
           })
       })
     })
@@ -70,33 +79,41 @@ describe('knockknock:fixture:single', () => {
   context('when synchronous', () => {
     before(() => knockknock.clearCache())
 
-    it('should return null', () => {
-      const caller = single.sync(helpers.createOptions())
+    it('should return empty array', () => {
+      const callers = single.sync(helpers.createOptions())
 
-      expect(caller).to.be.null
+      expect(callers).to.be.empty
+    })
+
+    context('and limited to a single caller via "limit"', () => {
+      it('should return promise for empty array', () => {
+        const callers = single.sync(helpers.createOptions({ limit: 1 }))
+
+        expect(callers).to.be.empty
+      })
     })
 
     context('and all files are excluded via "filterFiles"', () => {
-      it('should return null', () => {
-        const caller = single.sync(helpers.createOptions({ filterFiles: () => false }))
+      it('should return empty array', () => {
+        const callers = single.sync(helpers.createOptions({ filterFiles: () => false }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
 
     context('and package is excluded via "excludes"', () => {
-      it('should return null', () => {
-        const caller = single.sync(helpers.createOptions({ excludes: 'single' }))
+      it('should return empty array', () => {
+        const callers = single.sync(helpers.createOptions({ excludes: 'single' }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
 
     context('and package is excluded via "filterPackages"', () => {
-      it('should return null', () => {
-        const caller = single.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'single' }))
+      it('should return empty array', () => {
+        const callers = single.sync(helpers.createOptions({ filterPackages: (pkg) => pkg.name !== 'single' }))
 
-        expect(caller).to.be.null
+        expect(callers).to.be.empty
       })
     })
   })

--- a/test/knockknock.single.spec.js
+++ b/test/knockknock.single.spec.js
@@ -39,6 +39,15 @@ describe('knockknock:fixture:single', () => {
         })
     })
 
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for empty array', () => {
+        return single(helpers.createOptions({ offset: 1 }))
+          .then((callers) => {
+            expect(callers).to.be.empty
+          })
+      })
+    })
+
     context('and limited to a single caller via "limit"', () => {
       it('should return promise for empty array', () => {
         return single(helpers.createOptions({ limit: 1 }))
@@ -83,6 +92,14 @@ describe('knockknock:fixture:single', () => {
       const callers = single.sync(helpers.createOptions())
 
       expect(callers).to.be.empty
+    })
+
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for empty array', () => {
+        const callers = single.sync(helpers.createOptions({ offset: 1 }))
+
+        expect(callers).to.be.empty
+      })
     })
 
     context('and limited to a single caller via "limit"', () => {

--- a/test/knockknock.spec.js
+++ b/test/knockknock.spec.js
@@ -25,9 +25,45 @@
 const expect = require('chai').expect
 
 const knockknock = require('../src/knockknock')
+const helpers = require('./helpers')
+const internal = require('./fixtures/internal/src/internal')
 const version = require('../package.json').version
 
 describe('knockknock', () => {
+  context('when asynchronous', () => {
+    before(() => knockknock.clearCache())
+
+    it('should return promise for caller containing a copy of cached package information (#2)', () => {
+      let package1
+      let package2
+
+      return internal(helpers.createOptions())
+        .then((caller) => {
+          package1 = caller.package
+
+          return internal(helpers.createOptions())
+        })
+        .then((caller) => {
+          package2 = caller.package
+
+          expect(package1).to.not.equal(package2)
+          expect(package1).to.deep.equal(package2)
+        })
+    })
+  })
+
+  context('when synchronous', () => {
+    before(() => knockknock.clearCache())
+
+    it('should return caller containing a copy of cached package information (#2)', () => {
+      const package1 = internal.sync(helpers.createOptions()).package
+      const package2 = internal.sync(helpers.createOptions()).package
+
+      expect(package1).to.not.equal(package2)
+      expect(package1).to.deep.equal(package2)
+    })
+  })
+
   describe('.version', () => {
     it('should match package version', () => {
       expect(knockknock.version).to.equal(version)

--- a/test/knockknock.spec.js
+++ b/test/knockknock.spec.js
@@ -50,6 +50,21 @@ describe('knockknock', () => {
           expect(package1).to.deep.equal(package2)
         })
     })
+
+    context('and "filterPackages" option modifies package information', () => {
+      it('should have no affect on contained package information (#5)', () => {
+        return internal(helpers.createOptions({
+          filterPackages: (pkg) => {
+            pkg.name = 'bad'
+
+            return true
+          }
+        }))
+          .then((caller) => {
+            expect(caller.package.name).to.equal('internal')
+          })
+      })
+    })
   })
 
   context('when synchronous', () => {
@@ -61,6 +76,20 @@ describe('knockknock', () => {
 
       expect(package1).to.not.equal(package2)
       expect(package1).to.deep.equal(package2)
+    })
+
+    context('and "filterPackages" option modifies package information', () => {
+      it('should have no affect on contained package information (#5)', () => {
+        const caller = internal.sync(helpers.createOptions({
+          filterPackages: (pkg) => {
+            pkg.name = 'bad'
+
+            return true
+          }
+        }))
+
+        expect(caller.package.name).to.equal('internal')
+      })
     })
   })
 

--- a/test/knockknock.spec.js
+++ b/test/knockknock.spec.js
@@ -88,6 +88,24 @@ describe('knockknock', () => {
       })
     })
 
+    context('and "offset" is negative', () => {
+      it('should not apply an offset', () => {
+        return internal(helpers.createOptions({ offset: -1 }))
+          .then((callers) => {
+            expect(callers).to.have.lengthOf(2)
+          })
+      })
+    })
+
+    context('and "offset" is greater than size of call stack', () => {
+      it('should return promise for empty array', () => {
+        return internal(helpers.createOptions({ offset: 100 }))
+          .then((callers) => {
+            expect(callers).to.be.empty
+          })
+      })
+    })
+
     context('and "filterPackages" option modifies package', () => {
       it('should have no affect on contained package (#5)', () => {
         return internal(helpers.createOptions({
@@ -143,6 +161,22 @@ describe('knockknock', () => {
     context('and "limit" is zero', () => {
       it('should return empty array', () => {
         const callers = internal.sync(helpers.createOptions({ limit: 0 }))
+
+        expect(callers).to.be.empty
+      })
+    })
+
+    context('and "offset" is negative', () => {
+      it('should not apply an offset', () => {
+        const callers = internal.sync(helpers.createOptions({ offset: -1 }))
+
+        expect(callers).to.have.lengthOf(2)
+      })
+    })
+
+    context('and "offset" is greater than size of call stack', () => {
+      it('should return empty array', () => {
+        const callers = internal.sync(helpers.createOptions({ offset: 100 }))
 
         expect(callers).to.be.empty
       })

--- a/test/knockknock.unpacked.spec.js
+++ b/test/knockknock.unpacked.spec.js
@@ -27,6 +27,7 @@ const ncp = require('ncp').ncp
 const path = require('path')
 const tmp = require('tmp')
 
+const helpers = require('./helpers')
 const knockknock = require('../src/knockknock')
 
 describe('knockknock:fixture:unpackaged', () => {
@@ -75,6 +76,7 @@ describe('knockknock:fixture:unpackaged', () => {
         })
     })
 
+    // TODO: #7 Add tests covering use of "filterFiles" for unpackaged file
     // TODO: #7 Add test covering use of "filterPackages" for unpackaged file
   })
 
@@ -93,6 +95,7 @@ describe('knockknock:fixture:unpackaged', () => {
       })
     })
 
+    // TODO: #7 Add tests covering use of "filterFiles" for unpackaged file
     // TODO: #7 Add test covering use of "filterPackages" for unpackaged file
   })
 })

--- a/test/knockknock.unpacked.spec.js
+++ b/test/knockknock.unpacked.spec.js
@@ -74,6 +74,8 @@ describe('knockknock:fixture:unpackaged', () => {
           })
         })
     })
+
+    // TODO: #7 Add test covering use of "filterPackages" for unpackaged file
   })
 
   context('when synchronous', () => {
@@ -90,5 +92,7 @@ describe('knockknock:fixture:unpackaged', () => {
         package: null
       })
     })
+
+    // TODO: #7 Add test covering use of "filterPackages" for unpackaged file
   })
 })

--- a/test/knockknock.unpacked.spec.js
+++ b/test/knockknock.unpacked.spec.js
@@ -66,6 +66,7 @@ describe('knockknock:fixture:unpackaged', () => {
       return unpackaged(path.resolve(__dirname, '../'))
         .then((caller) => {
           expect(caller).to.deep.equal({
+            column: 10,
             file: path.join(tempDirPath, 'src', 'unpackaged.js'),
             line: 28,
             name: 'unpackagedFunction',
@@ -82,6 +83,7 @@ describe('knockknock:fixture:unpackaged', () => {
       const caller = unpackaged.sync(path.resolve(__dirname, '../'))
 
       expect(caller).to.deep.equal({
+        column: 14,
         file: path.join(tempDirPath, 'src', 'unpackaged.js'),
         line: 31,
         name: 'unpackagedSyncFunction',

--- a/test/knockknock.unpacked.spec.js
+++ b/test/knockknock.unpacked.spec.js
@@ -77,6 +77,15 @@ describe('knockknock:fixture:unpackaged', () => {
         })
     })
 
+    context('and first call is skipped via "offset"', () => {
+      it('should return promise for empty array', () => {
+        return unpackaged(path.resolve(__dirname, '../'), helpers.createOptions({ offset: 1 }))
+          .then((callers) => {
+            expect(callers).to.be.empty
+          })
+      })
+    })
+
     context('and limited to a single caller via "limit"', () => {
       it('should return promise for only caller (excl. package) before "knocking" file', () => {
         return unpackaged(path.resolve(__dirname, '../'), helpers.createOptions({ limit: 1 }))
@@ -142,6 +151,14 @@ describe('knockknock:fixture:unpackaged', () => {
         line: 31,
         name: 'unpackagedSyncFunction',
         package: null
+      })
+    })
+
+    context('and first call is skipped via "offset"', () => {
+      it('should return empty array', () => {
+        const callers = unpackaged.sync(path.resolve(__dirname, '../'), helpers.createOptions({ offset: 1 }))
+
+        expect(callers).to.be.empty
       })
     })
 


### PR DESCRIPTION
This release contains the following changes:

- [x] Add filterPackages option for more granular control over package exclusion #5
- [x] Add filterFiles option for more granular control over file exclusion #6
- [x] Return information for all callers #7 (**breaking change**)
- [x] Rename Git repository to node-knockknock #9
- [x] Add offset option for more control over initial call stack offset #10
- [x] All calls from start of stack from within originator module should be ignored #11